### PR TITLE
Simplify the overriding of particular aspects of the Committed theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@committed/components",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Committed Component Library",
   "author": "Committed",
   "license": "MIT",

--- a/src/stories/colour.stories.mdx
+++ b/src/stories/colour.stories.mdx
@@ -29,14 +29,14 @@ Full palletes back the main colours and are keyed with `50, 100, 200, 300, 400, 
 Click to copy color to clipboard.
 
 <ThemeProvider>
-  <Colors name="brand" colors={theme.palettes.brand} />
-  <Colors name="primary" colors={theme.palettes.primary} />
-  <Colors name="secondary" colors={theme.palettes.secondary} />
-  <Colors name="error" colors={theme.palettes.error} />
-  <Colors name="warning" colors={theme.palettes.warning} />
-  <Colors name="success" colors={theme.palettes.success} />
-  <Colors name="info" colors={theme.palettes.info} />
-  <Colors name="neutrals" colors={theme.palettes.neutral} />
+  <Colors name="brand" colors={theme.defaultPaletteColors.brand} />
+  <Colors name="primary" colors={theme.defaultPaletteColors.primary} />
+  <Colors name="secondary" colors={theme.defaultPaletteColors.secondary} />
+  <Colors name="error" colors={theme.defaultPaletteColors.error} />
+  <Colors name="warning" colors={theme.defaultPaletteColors.warning} />
+  <Colors name="success" colors={theme.defaultPaletteColors.success} />
+  <Colors name="info" colors={theme.defaultPaletteColors.info} />
+  <Colors name="neutrals" colors={theme.defaultPaletteColors.neutral} />
 </ThemeProvider>
 
 ## Colours

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -24,7 +24,9 @@ import { augmentColor } from './themeMaterialUtil'
 
 export interface ThemeProviderProps {
   /**
-   *  To override the font families used. default is used for Typography,
+   *  Should either return a `theme.FontOptions` object to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+   *
+   *  default is used for Typography,
    *  text for Text, display for Display and mono for Monospace.
    *
    *  typography: { fontFamily: '-apple-system, BlinkMacSystemFont, "San Francisco", Roboto,  "Segoe UI", "Helvetica Neue"'},
@@ -39,13 +41,32 @@ export interface ThemeProviderProps {
    *
    */
   createFonts?: () => FontOptions | undefined
+  /**
+   * Should either return a [set of material-ui color intentions](https://material-ui.com/customization/palette/#customization) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+   *
+   * The material-ui colors can be specified: palette.primary, palette.secondary, palette.error, palette.warning, palette.info or palette.success
+   *
+   * Additionally the committed-theme colors can be specified: palette.brand, palette.neutral
+   */
   createPaletteOptions?: () => PaletteOptions
+  /**
+   * Should either return material-ui shape options i.e. `{ borderRadius: xx }` to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+   */
   createShape?: () => ShapeOptions | undefined
+  /**
+   * Should either return [material-ui spacing options](https://material-ui.com/customization/spacing/) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+   */
   createSpacing?: () => SpacingOptions | undefined
+  /**
+   * Should either return [material-ui typography options](https://material-ui.com/customization/typography/) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+   */
   createTypography?: () =>
     | TypographyOptions
     | ((palette: Palette) => TypographyOptions)
     | undefined
+  /**
+   * Should either return [material-ui overrides options](https://material-ui.com/customization/globals/) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults. It is passed the palette created using the `createPaletteOptions()` prop
+   */
   createOverrides?: (palette: Palette) => Overrides | undefined
   children?: React.ReactNode
 }

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react'
 import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles'
 import { ThemeProvider as MuiThemeProvider } from '@material-ui/styles'
-import { BaseCSSProperties } from '@material-ui/styles/withStyles'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import { ThemeOptions } from '@material-ui/core/styles/createMuiTheme'
 import {
@@ -11,9 +10,10 @@ import {
   createCommittedSpacing,
   createCommittedTypography,
   createCommittedPaletteOptions,
-  defaultPaletteColors
+  defaultPaletteColors,
+  FontOptions
 } from './theme'
-import { defaultFonts } from './fonts'
+import deepmerge from 'deepmerge'
 import { PaletteOptions, Palette } from '@material-ui/core/styles/createPalette'
 import createMuiPalette from '@material-ui/core/styles/createPalette'
 import { ShapeOptions } from '@material-ui/core/styles/shape'
@@ -38,16 +38,8 @@ export interface ThemeProviderProps {
    *  monospace: { fontFamily: 'Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace' }
    *
    */
-  fonts?: {
-    typography?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    heading?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    subheading?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    text?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    display?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    monospace?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-  }
+  createFonts?: () => FontOptions | undefined
   createPaletteOptions?: () => PaletteOptions
-  createFonts?: () => typeof defaultFonts | undefined
   createShape?: () => ShapeOptions | undefined
   createSpacing?: () => SpacingOptions | undefined
   createTypography?: () =>
@@ -96,8 +88,9 @@ export const ThemeProvider: FC<ThemeProviderProps> = ({
   }
 
   const muiTheme = responsiveFontSizes(createMuiTheme(themeOptions))
+  const fonts = createFonts()
   return (
-    <MuiThemeProvider theme={muiTheme}>
+    <MuiThemeProvider theme={deepmerge(muiTheme, { fonts })}>
       <CssBaseline />
       <div {...rest} />
     </MuiThemeProvider>

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -5,9 +5,22 @@ import { ThemeProvider as MuiThemeProvider } from '@material-ui/styles'
 import { BaseCSSProperties } from '@material-ui/styles/withStyles'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import * as themes from './theme'
-import { defaultFonts } from './fonts'
 import { ThemeOptions } from '@material-ui/core/styles/createMuiTheme'
-import { createLightOptions, PaletteColors } from './theme'
+import {
+  PaletteColors,
+  createCommittedPalette,
+  createCommittedFonts,
+  createCommittedOverrides,
+  createCommittedShape,
+  createCommittedSpacing,
+  createCommittedTypography
+} from './theme'
+import { defaultFonts } from './fonts'
+import { PaletteOptions, Palette } from '@material-ui/core/styles/createPalette'
+import { ShapeOptions } from '@material-ui/core/styles/shape'
+import { SpacingOptions } from '@material-ui/core/styles/createSpacing'
+import { TypographyOptions } from '@material-ui/core/styles/createTypography'
+import { Overrides } from '@material-ui/core/styles/overrides'
 
 export interface ThemeProviderProps {
   /**
@@ -39,33 +52,44 @@ export interface ThemeProviderProps {
    *  Variants of each shade should be specified. Or a material-ui color preset should be used https://material-ui.com/customization/color/#color
    */
   paletteColors?: Partial<PaletteColors>
+  createPalette?: (paletteColors: PaletteColors) => PaletteOptions
+  createFonts?: () => typeof defaultFonts | undefined
+  createShape?: () => ShapeOptions | undefined
+  createSpacing?: () => SpacingOptions | undefined
+  createTypography?: () =>
+    | TypographyOptions
+    | ((palette: Palette) => TypographyOptions)
+    | undefined
+  createOverrides?: (paletteColors: PaletteColors) => Overrides | undefined
   children?: React.ReactNode
 }
 
 export const ThemeProvider: FC<ThemeProviderProps> = ({
-  fonts = {},
+  createPalette = createCommittedPalette,
+  createFonts = createCommittedFonts,
+  createOverrides = createCommittedOverrides,
+  createShape = createCommittedShape,
+  createSpacing = createCommittedSpacing,
+  createTypography = createCommittedTypography,
   paletteColors = {},
   ...rest
 }: ThemeProviderProps) => {
-  const defaultFont = fonts.typography || defaultFonts.typography
-  const allFonts = {
-    typography: defaultFont,
-    heading: fonts.heading || defaultFont,
-    subheading: fonts.subheading || fonts.heading || defaultFont,
-    text: fonts.text || defaultFont,
-    display: fonts.display || defaultFont,
-    monospace: fonts.monospace || defaultFonts.monospace
-  }
-  const lightOptions = createLightOptions(
-    deepmerge(themes.defaultPaletteColors, paletteColors)
+  const mergedPaletteColors = deepmerge(
+    themes.defaultPaletteColors,
+    paletteColors
   )
-  const theme: ThemeOptions = Object.assign({}, lightOptions, {
-    fonts: allFonts,
-    typography: Object.assign(lightOptions.typography, allFonts.typography)
-  })
-  const muiTheme = responsiveFontSizes(createMuiTheme(theme))
+  const themeOptions: ThemeOptions = {
+    palette: createPalette(mergedPaletteColors),
+    fonts: createFonts(),
+    shape: createShape(),
+    spacing: createSpacing(),
+    typography: createTypography(),
+    overrides: createOverrides(mergedPaletteColors)
+  }
+
+  const muiTheme = responsiveFontSizes(createMuiTheme(themeOptions))
   return (
-    <MuiThemeProvider theme={deepmerge(muiTheme, { fonts })}>
+    <MuiThemeProvider theme={muiTheme}>
       <CssBaseline />
       <div {...rest} />
     </MuiThemeProvider>

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -69,7 +69,7 @@ export const ThemeProvider: FC<ThemeProviderProps> = ({
 }: ThemeProviderProps) => {
   const paletteOptions = createPaletteOptions()
   const palette = createMuiPalette(paletteOptions)
-  // createMuiPalette() "augments" inputted colors (than may be in several forms) to make them conform to {main: #xxxx, light:#xxxx ,...etc}
+  // createMuiPalette() "augments" inputted colors (that may be in several forms) to make them conform to {main: #xxxx, light:#xxxx ,...etc}
   // manually augment committed custom theme colors that createMuiPalette is not aware of
   palette.success = augmentColor(
     paletteOptions.success,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -2,22 +2,28 @@ import * as allColors from './colors'
 import * as fonts from './fonts'
 import { fade, lighten } from '@material-ui/core/styles/colorManipulator'
 import { BaseCSSProperties } from '@material-ui/styles/withStyles'
-import { PaletteOptions } from '@material-ui/core/styles/createPalette'
+import {
+  PaletteOptions,
+  Palette,
+  PaletteColor
+} from '@material-ui/core/styles/createPalette'
 import { defaultFonts } from './fonts'
 import { Overrides } from '@material-ui/core/styles/overrides'
 
 declare module '@material-ui/core/styles/createPalette' {
   interface PaletteOptions {
-    success: PaletteColorOptions
-    warning: PaletteColorOptions
-    brand: PaletteColorOptions
-    info: PaletteColorOptions
+    success?: PaletteColorOptions
+    warning?: PaletteColorOptions
+    brand?: PaletteColorOptions
+    info?: PaletteColorOptions
+    neutral?: PaletteColorOptions
   }
 
   interface Palette {
     success: PaletteColor
     warning: PaletteColor
     info: PaletteColor
+    neutral: PaletteColor
   }
 }
 
@@ -92,15 +98,11 @@ export const defaultPaletteColors = {
   neutral: allColors.grey
 }
 
-export const createDefaultPalette = (paletteColors: PaletteColors) => ({
-  text: paletteColors.neutral[900]
-})
-
-const createCommittedText = (paletteColors: PaletteColors) => ({
-  primary: paletteColors.neutral[800],
-  secondary: paletteColors.neutral[700],
-  disabled: paletteColors.neutral[500],
-  hint: paletteColors.neutral[500]
+const createCommittedText = () => ({
+  primary: defaultPaletteColors.neutral[800],
+  secondary: defaultPaletteColors.neutral[700],
+  disabled: defaultPaletteColors.neutral[500],
+  hint: defaultPaletteColors.neutral[500]
 })
 
 const action = {
@@ -113,18 +115,17 @@ const action = {
 }
 
 export const createCommittedFonts = () => fonts.defaultFonts
-export const createCommittedPalette = (
-  paletteColors: PaletteColors
-): PaletteOptions => {
-  const palette = createDefaultPalette(paletteColors)
-  const text = createCommittedText(paletteColors)
+export const createCommittedPaletteOptions = (): PaletteOptions => {
+  const paletteColors = defaultPaletteColors
+  const text = createCommittedText()
+  const textColor = paletteColors.neutral[900]
   return {
     type: 'light',
     brand: {
       light: paletteColors.brand[300],
       main: paletteColors.brand[500],
       dark: paletteColors.brand[700],
-      contrastText: palette.text
+      contrastText: textColor
     },
     primary: {
       light: paletteColors.primary[400],
@@ -143,19 +144,19 @@ export const createCommittedPalette = (
       light: paletteColors.success[300],
       main: paletteColors.success[500],
       dark: paletteColors.success[700],
-      contrastText: palette.text
+      contrastText: textColor
     },
     warning: {
       light: paletteColors.warning[200],
       main: paletteColors.warning[400],
       dark: paletteColors.warning[600],
-      contrastText: palette.text
+      contrastText: textColor
     },
     info: {
       light: paletteColors.info[100],
       main: paletteColors.info[300],
       dark: paletteColors.info[500],
-      contrastText: palette.text
+      contrastText: textColor
     },
     background: {
       default: paletteColors.neutral[50],
@@ -163,6 +164,7 @@ export const createCommittedPalette = (
     },
     text,
     grey: paletteColors.neutral,
+    neutral: paletteColors.neutral,
     action,
     divider: 'rgba(0, 0, 0, 0.12)'
   }
@@ -221,10 +223,23 @@ export const createCommittedShape = () => ({
   borderRadius: 2
 })
 
-export const createCommittedOverrides = (
-  paletteColors: PaletteColors
-): Overrides => {
-  const text = createCommittedText(paletteColors)
+// eqiv to color[400]
+const mainLight = (color: PaletteColor): string => {
+  return lighten(color.main, 0.25)
+}
+
+// color[200]
+const lightLight = (color: PaletteColor): string => {
+  return lighten(color.light, 0.25)
+}
+
+// color[100]
+const lightLightVery = (color: PaletteColor): string => {
+  return lighten(color.light, 0.5)
+}
+
+export const createCommittedOverrides = (palette: Palette): Overrides => {
+  const text = createCommittedText()
   return {
     MuiButton: {
       root: {
@@ -232,32 +247,23 @@ export const createCommittedOverrides = (
       },
       contained: {
         '&:hover': {
-          backgroundColor: lighten(
-            paletteColors.primary[300],
-            action.hoverOpacity
-          )
+          backgroundColor: lighten(palette.primary.light, action.hoverOpacity)
         },
         '&$disabled': {
-          color: addTransparency(text.primary),
-          backgroundColor: addTransparency(paletteColors.neutral[300])
+          backgroundColor: addTransparency(palette.neutral.light)
         }
       },
       containedPrimary: {
         '&:hover': {
-          backgroundColor: lighten(
-            paletteColors.primary[500],
-            action.hoverOpacity
-          )
+          backgroundColor: lighten(palette.primary.main, action.hoverOpacity)
         },
         '&$disabled': {
-          backgroundColor: addTransparency(paletteColors.primary[500]),
-          color: addTransparency(paletteColors.secondary[500])
+          backgroundColor: addTransparency(palette.primary.main)
         }
       },
       containedSecondary: {
         '&$disabled': {
-          backgroundColor: addTransparency(paletteColors.secondary[200]),
-          color: addTransparency(paletteColors.primary[500])
+          backgroundColor: addTransparency(lightLight(palette.secondary))
         }
       },
       text: {
@@ -266,106 +272,84 @@ export const createCommittedOverrides = (
         }
       },
       textPrimary: {
-        color: paletteColors.primary[500],
+        color: palette.primary.main,
         '&:hover': {
-          backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
+          backgroundColor: fade(palette.brand.main, action.hoverOpacity)
         },
-        '& span:nth-of-type(2)': {
-          color: paletteColors.brand[500]
-        },
-        '&$disabled': {
-          color: addTransparency(paletteColors.primary[500])
-        }
+        '&$disabled': {}
       },
       textSecondary: {
-        color: paletteColors.brand[800],
+        color: palette.brand.dark,
         '&:hover': {
-          backgroundColor: fade(paletteColors.primary[500], action.hoverOpacity)
-        },
-        '& span:nth-of-type(2)': {
-          color: paletteColors.primary[500]
-        },
-        '&$disabled': {
-          color: addTransparency(paletteColors.brand[500])
+          backgroundColor: fade(palette.primary.main, action.hoverOpacity)
         }
       },
       outlined: {
         '&$disabled': {
-          borderColor: addTransparency(paletteColors.neutral[500]),
-          color: addTransparency(paletteColors.neutral[200])
+          borderColor: addTransparency(palette.neutral.main),
+          color: addTransparency(lightLight(palette.neutral))
         }
       },
       outlinedPrimary: {
-        backgroundColor: paletteColors.brand[100],
+        backgroundColor: lightLightVery(palette.brand),
         '&:hover': {
-          backgroundColor: paletteColors.brand[200]
-        },
-        '& span:nth-of-type(2)': {
-          color: paletteColors.brand[500]
+          backgroundColor: lightLight(palette.brand)
         },
         '&$disabled': {
-          backgroundColor: addTransparency(paletteColors.brand[100]),
-          borderColor: addTransparency(paletteColors.primary[500]),
-          color: addTransparency(paletteColors.primary[500])
+          backgroundColor: addTransparency(lightLightVery(palette.brand)),
+          borderColor: addTransparency(palette.primary.main)
         }
       },
       outlinedSecondary: {
-        backgroundColor: paletteColors.primary[400],
+        backgroundColor: mainLight(palette.primary),
         '&:hover': {
           backgroundColor: lighten(
-            paletteColors.primary[400],
+            mainLight(palette.primary),
             action.hoverOpacity
           )
         },
-        '& span:nth-of-type(2)': {
-          color: paletteColors.primary[500]
-        },
         '&$disabled': {
-          backgroundColor: addTransparency(paletteColors.primary[400]),
-          borderColor: addTransparency(paletteColors.secondary[300]),
-          color: addTransparency(paletteColors.secondary[300])
+          backgroundColor: addTransparency(mainLight(palette.primary)),
+          borderColor: addTransparency(palette.secondary.light)
         }
       },
       disabled: {}
     },
     MuiCheckbox: {
       root: {
-        color: paletteColors.neutral[500],
+        color: palette.neutral.main,
         '&$disabled': {
-          color: addTransparency(paletteColors.neutral[500])
+          color: addTransparency(palette.neutral.main)
         }
       },
       colorPrimary: {
-        color: paletteColors.primary[500],
+        color: palette.primary.main,
         '&$checked': {
-          color: paletteColors.primary[500],
+          color: palette.primary.main,
           '&:hover': {
-            backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
+            backgroundColor: fade(palette.brand.main, action.hoverOpacity)
           }
         },
         '& span:nth-of-type(2)': {
-          color: paletteColors.brand[500]
+          color: palette.brand.main
         },
         '&$disabled': {
-          color: addTransparency(paletteColors.primary[500])
+          color: addTransparency(palette.primary.main)
         }
       },
       colorSecondary: {
-        color: paletteColors.secondary[300],
+        color: palette.secondary.light,
         '&$checked': {
-          color: paletteColors.secondary[300],
+          color: palette.secondary.light,
           '&:hover': {
-            backgroundColor: fade(
-              paletteColors.primary[500],
-              action.hoverOpacity
-            )
+            backgroundColor: fade(palette.primary.main, action.hoverOpacity)
           }
         },
         '& span:nth-of-type(2)': {
-          color: paletteColors.primary[500]
+          color: palette.primary.main
         },
         '&$disabled': {
-          color: addTransparency(paletteColors.secondary[300])
+          color: addTransparency(palette.secondary.light)
         }
       }
     },
@@ -387,7 +371,7 @@ export const createCommittedOverrides = (
     },
     MuiDialog: {
       paper: {
-        borderTop: `4px solid ${paletteColors.brand[500]}`
+        borderTop: `4px solid ${palette.brand.main}`
       }
     },
     MuiDivider: {
@@ -399,85 +383,82 @@ export const createCommittedOverrides = (
     MuiIconButton: {
       colorPrimary: {
         '&:hover': {
-          backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
+          backgroundColor: fade(palette.brand.main, action.hoverOpacity)
         },
         '& span:nth-of-type(2)': {
-          color: paletteColors.brand[500]
+          color: palette.brand.main
         }
       },
       colorSecondary: {
-        color: paletteColors.brand[800],
+        color: palette.brand.dark,
         '&:hover': {
-          backgroundColor: fade(paletteColors.primary[500], action.hoverOpacity)
+          backgroundColor: fade(palette.primary.main, action.hoverOpacity)
         },
         '& span:nth-of-type(2)': {
-          color: paletteColors.primary[500]
+          color: palette.primary.main
         }
       }
     },
     MuiRadio: {
       root: {
-        color: paletteColors.neutral[500],
+        color: palette.neutral.main,
         '&$disabled': {
-          color: addTransparency(paletteColors.neutral[500])
+          color: addTransparency(palette.neutral.main)
         }
       },
       colorPrimary: {
-        color: paletteColors.primary[500],
+        color: palette.primary.main,
         '&$checked': {
-          color: paletteColors.primary[500],
+          color: palette.primary.main,
           '&:hover': {
-            backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
+            backgroundColor: fade(palette.brand.main, action.hoverOpacity)
           }
         },
         '& span:nth-of-type(2)': {
-          color: paletteColors.brand[500]
+          color: palette.brand.main
         },
         '& svg:nth-of-type(2)': {
-          color: paletteColors.brand[500]
+          color: palette.brand.main
         },
         '&$disabled': {
-          color: addTransparency(paletteColors.primary[500]),
+          color: addTransparency(palette.primary.main),
           '& svg:nth-of-type(2)': {
-            color: addTransparency(paletteColors.brand[500])
+            color: addTransparency(palette.brand.main)
           }
         }
       },
       colorSecondary: {
-        color: paletteColors.secondary[300],
+        color: palette.secondary.light,
         '&$checked': {
-          color: paletteColors.secondary[300],
+          color: palette.secondary.light,
           '&:hover': {
-            backgroundColor: fade(
-              paletteColors.primary[500],
-              action.hoverOpacity
-            )
+            backgroundColor: fade(palette.primary.main, action.hoverOpacity)
           }
         },
         '& span:nth-of-type(2)': {
-          color: paletteColors.primary[500]
+          color: palette.primary.main
         },
         '& svg:nth-of-type(2)': {
-          color: paletteColors.primary[500]
+          color: palette.primary.main
         },
         '&$disabled': {
-          color: addTransparency(paletteColors.secondary[300]),
+          color: addTransparency(palette.secondary.light),
           '& svg:nth-of-type(2)': {
-            color: addTransparency(paletteColors.primary[500])
+            color: addTransparency(palette.primary.main)
           }
         }
       }
     },
     MuiSwitch: {
       root: {
-        color: paletteColors.neutral[500],
+        color: palette.neutral.main,
         '&$disabled': {
-          color: addTransparency(paletteColors.neutral[500])
+          color: addTransparency(palette.neutral.main)
         }
       },
       colorPrimary: {
         '&$checked + $track': {
-          backgroundColor: paletteColors.brand[500]
+          backgroundColor: palette.brand.main
         }
       }
     },
@@ -487,20 +468,20 @@ export const createCommittedOverrides = (
           fontWeight: 'bold',
           color: text.primary
         },
-        borderBottom: `2px solid ${paletteColors.brand[500]}`
+        borderBottom: `2px solid ${palette.brand.main}`
       }
     },
     MuiTableBody: {
       root: {
         '& tr:nth-child(even)': {
-          backgroundColor: paletteColors.neutral[100]
+          backgroundColor: lightLightVery(palette.neutral)
         },
-        borderColor: paletteColors.neutral[100]
+        borderColor: lightLightVery(palette.neutral)
       }
     },
     MuiTableCell: {
       body: {
-        borderBottomColor: paletteColors.neutral[100]
+        borderBottomColor: lightLightVery(palette.neutral)
       }
     },
     MuiTableFooter: {
@@ -509,13 +490,13 @@ export const createCommittedOverrides = (
           fontWeight: 'bold',
           color: text.primary
         },
-        borderTop: `2px solid ${paletteColors.brand[500]}`,
-        borderBottom: `2px solid ${paletteColors.brand[500]}`
+        borderTop: `2px solid ${palette.brand.main}`,
+        borderBottom: `2px solid ${palette.brand.main}`
       }
     },
     MuiTabs: {
       indicator: {
-        backgroundColor: paletteColors.brand[500],
+        backgroundColor: palette.brand.main,
         height: '4px'
       }
     }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -37,27 +37,24 @@ export type FontType =
 
 export type PaletteColors = typeof defaultPaletteColors
 
+export interface Fonts {
+  typography: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
+  heading: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
+  subheading: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
+  text: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
+  display: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
+  monospace: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
+}
+
+export type FontOptions = Partial<Fonts>
+
 declare module '@material-ui/core/styles/createMuiTheme' {
   interface Theme {
-    fonts: {
-      typography: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      heading: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      subheading: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      text: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      display: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      monospace: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    }
+    fonts: Fonts
   }
   // allow configuration using `createMuiTheme`
   interface ThemeOptions {
-    fonts?: {
-      typography?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      heading?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      subheading?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      text?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      display?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-      monospace?: { [P in keyof BaseCSSProperties]: BaseCSSProperties[P] }
-    }
+    fonts?: FontOptions
   }
 }
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -2,6 +2,9 @@ import * as allColors from './colors'
 import * as fonts from './fonts'
 import { fade, lighten } from '@material-ui/core/styles/colorManipulator'
 import { BaseCSSProperties } from '@material-ui/styles/withStyles'
+import { PaletteOptions } from '@material-ui/core/styles/createPalette'
+import { defaultFonts } from './fonts'
+import { Overrides } from '@material-ui/core/styles/overrides'
 
 declare module '@material-ui/core/styles/createPalette' {
   interface PaletteOptions {
@@ -89,11 +92,11 @@ export const defaultPaletteColors = {
   neutral: allColors.grey
 }
 
-export const createPalette = (paletteColors: PaletteColors) => ({
+export const createDefaultPalette = (paletteColors: PaletteColors) => ({
   text: paletteColors.neutral[900]
 })
 
-const createText = (paletteColors: PaletteColors) => ({
+const createCommittedText = (paletteColors: PaletteColors) => ({
   primary: paletteColors.neutral[800],
   secondary: paletteColors.neutral[700],
   disabled: paletteColors.neutral[500],
@@ -109,415 +112,411 @@ const action = {
   disabledBackground: 'rgba(0, 0, 0, 0.12)'
 }
 
-export const createLightOptions = (paletteColors: PaletteColors) => {
-  const palette = createPalette(paletteColors)
-  const text = createText(paletteColors)
+export const createCommittedFonts = () => fonts.defaultFonts
+export const createCommittedPalette = (
+  paletteColors: PaletteColors
+): PaletteOptions => {
+  const palette = createDefaultPalette(paletteColors)
+  const text = createCommittedText(paletteColors)
   return {
-    fonts: fonts.defaultFonts,
-    palette: {
-      type: 'light',
-      brand: {
-        light: paletteColors.brand[300],
-        main: paletteColors.brand[500],
-        dark: paletteColors.brand[700],
-        contrastText: palette.text
-      },
-      primary: {
-        light: paletteColors.primary[400],
-        main: paletteColors.primary[600],
-        dark: paletteColors.primary[800],
-        contrastText: paletteColors.brand[500]
-      },
-      secondary: {
-        contrastText: paletteColors.primary[500]
-        light: paletteColors.secondary[300],
-        main: paletteColors.secondary[500],
-        dark: paletteColors.secondary[700]
-      },
-      error: paletteColors.error,
-      success: {
-        light: paletteColors.success[300],
-        main: paletteColors.success[500],
-        dark: paletteColors.success[700],
-        contrastText: palette.text
-      },
-      warning: {
-        light: paletteColors.warning[200],
-        main: paletteColors.warning[400],
-        dark: paletteColors.warning[600],
-        contrastText: palette.text
-      },
-      info: {
-        light: paletteColors.info[100],
-        main: paletteColors.info[300],
-        dark: paletteColors.info[500],
-        contrastText: palette.text
-      },
-      background: {
-        default: paletteColors.neutral[50],
-        paper: 'white'
-      },
-      text,
-      grey: paletteColors.neutral,
-      action,
-      divider: 'rgba(0, 0, 0, 0.12)'
+    type: 'light',
+    brand: {
+      light: paletteColors.brand[300],
+      main: paletteColors.brand[500],
+      dark: paletteColors.brand[700],
+      contrastText: palette.text
     },
-    spacing: spacing,
-    typography: {
-      htmlFontSize: 16,
-      fontSize: 16,
-      fontWeightLight: 300,
-      fontWeightRegular: 400,
-      fontWeightMedium: 500,
-      fontWeightBold: 700,
-      h1: {
-        fontSize: fonts.sizes[5]
+    primary: {
+      light: paletteColors.primary[400],
+      main: paletteColors.primary[600],
+      dark: paletteColors.primary[800],
+      contrastText: paletteColors.brand[500]
+    },
+    secondary: {
+      light: paletteColors.secondary[300],
+      main: paletteColors.secondary[500],
+      dark: paletteColors.secondary[700],
+      contrastText: paletteColors.primary[500]
+    },
+    error: paletteColors.error,
+    success: {
+      light: paletteColors.success[300],
+      main: paletteColors.success[500],
+      dark: paletteColors.success[700],
+      contrastText: palette.text
+    },
+    warning: {
+      light: paletteColors.warning[200],
+      main: paletteColors.warning[400],
+      dark: paletteColors.warning[600],
+      contrastText: palette.text
+    },
+    info: {
+      light: paletteColors.info[100],
+      main: paletteColors.info[300],
+      dark: paletteColors.info[500],
+      contrastText: palette.text
+    },
+    background: {
+      default: paletteColors.neutral[50],
+      paper: 'white'
+    },
+    text,
+    grey: paletteColors.neutral,
+    action,
+    divider: 'rgba(0, 0, 0, 0.12)'
+  }
+}
+export const createCommittedSpacing = () => spacing
+export const createCommittedTypography = () => ({
+  htmlFontSize: 16,
+  fontSize: 16,
+  fontWeightLight: 300,
+  fontWeightRegular: 400,
+  fontWeightMedium: 500,
+  fontWeightBold: 700,
+  h1: {
+    fontSize: fonts.sizes[5]
+  },
+  h2: {
+    fontSize: fonts.sizes[4]
+  },
+  h3: {
+    fontSize: fonts.sizes[3]
+  },
+  h4: {
+    fontSize: fonts.sizes[2]
+  },
+  h5: {
+    fontSize: fonts.sizes[1]
+  },
+  h6: {
+    fontSize: fonts.sizes[0]
+  },
+  subtitle1: {
+    fontSize: fonts.sizes[0]
+  },
+  subtitle2: {
+    fontSize: fonts.sizes[-1]
+  },
+  body1: {
+    fontSize: fonts.sizes[0]
+  },
+  body2: {
+    fontSize: fonts.sizes[1]
+  },
+  button: {
+    fontSize: fonts.sizes[0]
+  },
+  caption: {
+    fontSize: fonts.sizes[-1]
+  },
+  overline: {
+    fontSize: fonts.sizes[-1]
+  },
+  ...defaultFonts.typography
+})
+
+export const createCommittedShape = () => ({
+  borderRadius: 2
+})
+
+export const createCommittedOverrides = (
+  paletteColors: PaletteColors
+): Overrides => {
+  const text = createCommittedText(paletteColors)
+  return {
+    MuiButton: {
+      root: {
+        textTransform: 'none'
       },
-      h2: {
-        fontSize: fonts.sizes[4]
+      contained: {
+        '&:hover': {
+          backgroundColor: lighten(
+            paletteColors.primary[300],
+            action.hoverOpacity
+          )
+        },
+        '&$disabled': {
+          color: addTransparency(text.primary),
+          backgroundColor: addTransparency(paletteColors.neutral[300])
+        }
       },
-      h3: {
-        fontSize: fonts.sizes[3]
+      containedPrimary: {
+        '&:hover': {
+          backgroundColor: lighten(
+            paletteColors.primary[500],
+            action.hoverOpacity
+          )
+        },
+        '&$disabled': {
+          backgroundColor: addTransparency(paletteColors.primary[500]),
+          color: addTransparency(paletteColors.secondary[500])
+        }
       },
-      h4: {
-        fontSize: fonts.sizes[2]
+      containedSecondary: {
+        '&$disabled': {
+          backgroundColor: addTransparency(paletteColors.secondary[200]),
+          color: addTransparency(paletteColors.primary[500])
+        }
       },
-      h5: {
-        fontSize: fonts.sizes[1]
+      text: {
+        '&$disabled': {
+          color: addTransparency(text.primary)
+        }
       },
-      h6: {
-        fontSize: fonts.sizes[0]
+      textPrimary: {
+        color: paletteColors.primary[500],
+        '&:hover': {
+          backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
+        },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.brand[500]
+        },
+        '&$disabled': {
+          color: addTransparency(paletteColors.primary[500])
+        }
       },
-      subtitle1: {
-        fontSize: fonts.sizes[0]
+      textSecondary: {
+        color: paletteColors.brand[800],
+        '&:hover': {
+          backgroundColor: fade(paletteColors.primary[500], action.hoverOpacity)
+        },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.primary[500]
+        },
+        '&$disabled': {
+          color: addTransparency(paletteColors.brand[500])
+        }
       },
-      subtitle2: {
-        fontSize: fonts.sizes[-1]
+      outlined: {
+        '&$disabled': {
+          borderColor: addTransparency(paletteColors.neutral[500]),
+          color: addTransparency(paletteColors.neutral[200])
+        }
       },
-      body1: {
-        fontSize: fonts.sizes[0]
+      outlinedPrimary: {
+        backgroundColor: paletteColors.brand[100],
+        '&:hover': {
+          backgroundColor: paletteColors.brand[200]
+        },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.brand[500]
+        },
+        '&$disabled': {
+          backgroundColor: addTransparency(paletteColors.brand[100]),
+          borderColor: addTransparency(paletteColors.primary[500]),
+          color: addTransparency(paletteColors.primary[500])
+        }
       },
-      body2: {
-        fontSize: fonts.sizes[1]
+      outlinedSecondary: {
+        backgroundColor: paletteColors.primary[400],
+        '&:hover': {
+          backgroundColor: lighten(
+            paletteColors.primary[400],
+            action.hoverOpacity
+          )
+        },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.primary[500]
+        },
+        '&$disabled': {
+          backgroundColor: addTransparency(paletteColors.primary[400]),
+          borderColor: addTransparency(paletteColors.secondary[300]),
+          color: addTransparency(paletteColors.secondary[300])
+        }
       },
-      button: {
-        fontSize: fonts.sizes[0]
+      disabled: {}
+    },
+    MuiCheckbox: {
+      root: {
+        color: paletteColors.neutral[500],
+        '&$disabled': {
+          color: addTransparency(paletteColors.neutral[500])
+        }
       },
-      caption: {
-        fontSize: fonts.sizes[-1]
+      colorPrimary: {
+        color: paletteColors.primary[500],
+        '&$checked': {
+          color: paletteColors.primary[500],
+          '&:hover': {
+            backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
+          }
+        },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.brand[500]
+        },
+        '&$disabled': {
+          color: addTransparency(paletteColors.primary[500])
+        }
       },
-      overline: {
-        fontSize: fonts.sizes[-1]
+      colorSecondary: {
+        color: paletteColors.secondary[300],
+        '&$checked': {
+          color: paletteColors.secondary[300],
+          '&:hover': {
+            backgroundColor: fade(
+              paletteColors.primary[500],
+              action.hoverOpacity
+            )
+          }
+        },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.primary[500]
+        },
+        '&$disabled': {
+          color: addTransparency(paletteColors.secondary[300])
+        }
       }
     },
-    shape: {
-      borderRadius: 2
+    MuiCssBaseline: {
+      '@global': {
+        /* Disable auto-enlargement of small text in Safari */
+        textSizeAdjust: '100%',
+        /* Enable kerning and optional ligatures */
+        textRendering: 'optimizeLegibility',
+        /**
+         * Form elements render using OS defaults,
+         * so font-family inheritance must be specifically declared
+         */
+        'button, input, optgroup, select, textarea': {
+          fontFamily: 'inherit',
+          fontSize: 'inherit'
+        }
+      }
     },
-    overrides: {
-      MuiButton: {
-        root: {
-          textTransform: 'none'
+    MuiDialog: {
+      paper: {
+        borderTop: `4px solid ${paletteColors.brand[500]}`
+      }
+    },
+    MuiDivider: {
+      vertical: {
+        // 100% is the default, this doesn't seem to work so set to auto
+        height: 'auto'
+      }
+    },
+    MuiIconButton: {
+      colorPrimary: {
+        '&:hover': {
+          backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
         },
-        contained: {
-          '&:hover': {
-            backgroundColor: lighten(
-              paletteColors.primary[300],
-              action.hoverOpacity
-            )
-          },
-          '&$disabled': {
-            color: addTransparency(text.primary),
-            backgroundColor: addTransparency(paletteColors.neutral[300])
-          }
+        '& span:nth-of-type(2)': {
+          color: paletteColors.brand[500]
+        }
+      },
+      colorSecondary: {
+        color: paletteColors.brand[800],
+        '&:hover': {
+          backgroundColor: fade(paletteColors.primary[500], action.hoverOpacity)
         },
-        containedPrimary: {
-          '&:hover': {
-            backgroundColor: lighten(
-              paletteColors.primary[500],
-              action.hoverOpacity
-            )
-          },
-          '&$disabled': {
-            backgroundColor: addTransparency(paletteColors.primary[500]),
-            color: addTransparency(paletteColors.secondary[500])
-          }
-        },
-        containedSecondary: {
-          '&$disabled': {
-            backgroundColor: addTransparency(paletteColors.secondary[200]),
-            color: addTransparency(paletteColors.primary[500])
-          }
-        },
-        text: {
-          '&$disabled': {
-            color: addTransparency(text.primary)
-          }
-        },
-        textPrimary: {
+        '& span:nth-of-type(2)': {
+          color: paletteColors.primary[500]
+        }
+      }
+    },
+    MuiRadio: {
+      root: {
+        color: paletteColors.neutral[500],
+        '&$disabled': {
+          color: addTransparency(paletteColors.neutral[500])
+        }
+      },
+      colorPrimary: {
+        color: paletteColors.primary[500],
+        '&$checked': {
           color: paletteColors.primary[500],
           '&:hover': {
             backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.brand[500]
-          },
-          '&$disabled': {
-            color: addTransparency(paletteColors.primary[500])
           }
         },
-        textSecondary: {
-          color: paletteColors.brand[800],
-          '&:hover': {
-            backgroundColor: fade(
-              paletteColors.primary[500],
-              action.hoverOpacity
-            )
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.primary[500]
-          },
-          '&$disabled': {
+        '& span:nth-of-type(2)': {
+          color: paletteColors.brand[500]
+        },
+        '& svg:nth-of-type(2)': {
+          color: paletteColors.brand[500]
+        },
+        '&$disabled': {
+          color: addTransparency(paletteColors.primary[500]),
+          '& svg:nth-of-type(2)': {
             color: addTransparency(paletteColors.brand[500])
           }
-        },
-        outlined: {
-          '&$disabled': {
-            borderColor: addTransparency(paletteColors.neutral[500]),
-            color: addTransparency(paletteColors.neutral[200])
-          }
-        },
-        outlinedPrimary: {
-          backgroundColor: paletteColors.brand[100],
-          '&:hover': {
-            backgroundColor: paletteColors.brand[200]
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.brand[500]
-          },
-          '&$disabled': {
-            backgroundColor: addTransparency(paletteColors.brand[100]),
-            borderColor: addTransparency(paletteColors.primary[500]),
-            color: addTransparency(paletteColors.primary[500])
-          }
-        },
-        outlinedSecondary: {
-          backgroundColor: paletteColors.primary[400],
-          '&:hover': {
-            backgroundColor: lighten(
-              paletteColors.primary[400],
-              action.hoverOpacity
-            )
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.primary[500]
-          },
-          '&$disabled': {
-            backgroundColor: addTransparency(paletteColors.primary[400]),
-            borderColor: addTransparency(paletteColors.secondary[300]),
-            color: addTransparency(paletteColors.secondary[300])
-          }
-        },
-        disabled: {}
+        }
       },
-      MuiCheckbox: {
-        root: {
-          color: paletteColors.neutral[500],
-          '&$disabled': {
-            color: addTransparency(paletteColors.neutral[500])
-          }
-        },
-        colorPrimary: {
-          color: paletteColors.primary[500],
-          '&$checked': {
-            color: paletteColors.primary[500],
-            '&:hover': {
-              backgroundColor: fade(
-                paletteColors.brand[500],
-                action.hoverOpacity
-              )
-            }
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.brand[500]
-          },
-          '&$disabled': {
-            color: addTransparency(paletteColors.primary[500])
-          }
-        },
-        colorSecondary: {
+      colorSecondary: {
+        color: paletteColors.secondary[300],
+        '&$checked': {
           color: paletteColors.secondary[300],
-          '&$checked': {
-            color: paletteColors.secondary[300],
-            '&:hover': {
-              backgroundColor: fade(
-                paletteColors.primary[500],
-                action.hoverOpacity
-              )
-            }
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.primary[500]
-          },
-          '&$disabled': {
-            color: addTransparency(paletteColors.secondary[300])
-          }
-        }
-      },
-      MuiCssBaseline: {
-        '@global': {
-          /* Disable auto-enlargement of small text in Safari */
-          textSizeAdjust: '100%',
-          /* Enable kerning and optional ligatures */
-          textRendering: 'optimizeLegibility',
-          /**
-           * Form elements render using OS defaults,
-           * so font-family inheritance must be specifically declared
-           */
-          'button, input, optgroup, select, textarea': {
-            fontFamily: 'inherit',
-            fontSize: 'inherit'
-          }
-        }
-      },
-      MuiDialog: {
-        paper: {
-          borderTop: `4px solid ${allColors.committedYellow[500]}`
-        }
-      },
-      MuiDivider: {
-        vertical: {
-          // 100% is the default, this doesn't seem to work so set to auto
-          height: 'auto'
-        }
-      },
-      MuiIconButton: {
-        colorPrimary: {
-          '&:hover': {
-            backgroundColor: fade(paletteColors.brand[500], action.hoverOpacity)
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.brand[500]
-          }
-        },
-        colorSecondary: {
-          color: paletteColors.brand[800],
           '&:hover': {
             backgroundColor: fade(
               paletteColors.primary[500],
               action.hoverOpacity
             )
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.primary[500]
-          }
-        }
-      },
-      MuiRadio: {
-        root: {
-          color: paletteColors.neutral[500],
-          '&$disabled': {
-            color: addTransparency(paletteColors.neutral[500])
           }
         },
-        colorPrimary: {
-          color: paletteColors.primary[500],
-          '&$checked': {
-            color: paletteColors.primary[500],
-            '&:hover': {
-              backgroundColor: fade(
-                paletteColors.brand[500],
-                action.hoverOpacity
-              )
-            }
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.brand[500]
-          },
+        '& span:nth-of-type(2)': {
+          color: paletteColors.primary[500]
+        },
+        '& svg:nth-of-type(2)': {
+          color: paletteColors.primary[500]
+        },
+        '&$disabled': {
+          color: addTransparency(paletteColors.secondary[300]),
           '& svg:nth-of-type(2)': {
-            color: paletteColors.brand[500]
-          },
-          '&$disabled': {
-            color: addTransparency(paletteColors.primary[500]),
-            '& svg:nth-of-type(2)': {
-              color: addTransparency(paletteColors.brand[500])
-            }
+            color: addTransparency(paletteColors.primary[500])
           }
+        }
+      }
+    },
+    MuiSwitch: {
+      root: {
+        color: paletteColors.neutral[500],
+        '&$disabled': {
+          color: addTransparency(paletteColors.neutral[500])
+        }
+      },
+      colorPrimary: {
+        '&$checked + $track': {
+          backgroundColor: paletteColors.brand[500]
+        }
+      }
+    },
+    MuiTableHead: {
+      root: {
+        '& th': {
+          fontWeight: 'bold',
+          color: text.primary
         },
-        colorSecondary: {
-          color: paletteColors.secondary[300],
-          '&$checked': {
-            color: paletteColors.secondary[300],
-            '&:hover': {
-              backgroundColor: fade(
-                paletteColors.primary[500],
-                action.hoverOpacity
-              )
-            }
-          },
-          '& span:nth-of-type(2)': {
-            color: paletteColors.primary[500]
-          },
-          '& svg:nth-of-type(2)': {
-            color: paletteColors.primary[500]
-          },
-          '&$disabled': {
-            color: addTransparency(paletteColors.secondary[300]),
-            '& svg:nth-of-type(2)': {
-              color: addTransparency(paletteColors.primary[500])
-            }
-          }
-        }
-      },
-      MuiSwitch: {
-        root: {
-          color: paletteColors.neutral[500],
-          '&$disabled': {
-            color: addTransparency(paletteColors.neutral[500])
-          }
+        borderBottom: `2px solid ${paletteColors.brand[500]}`
+      }
+    },
+    MuiTableBody: {
+      root: {
+        '& tr:nth-child(even)': {
+          backgroundColor: paletteColors.neutral[100]
         },
-        colorPrimary: {
-          '&$checked + $track': {
-            backgroundColor: paletteColors.brand[500]
-          }
-        }
-      },
-      MuiTableHead: {
-        root: {
-          '& th': {
-            fontWeight: 'bold',
-            color: text.primary
-          },
-          borderBottom: `2px solid ${paletteColors.brand[500]}`
-        }
-      },
-      MuiTableBody: {
-        root: {
-          '& tr:nth-child(even)': {
-            backgroundColor: paletteColors.neutral[100]
-          },
-          borderColor: paletteColors.neutral[100]
-        }
-      },
-      MuiTableCell: {
-        body: {
-          borderBottomColor: paletteColors.neutral[100]
-        }
-      },
-      MuiTableFooter: {
-        root: {
-          '& th,td': {
-            fontWeight: 'bold',
-            color: text.primary
-          },
-          borderTop: `2px solid ${paletteColors.brand[500]}`,
-          borderBottom: `2px solid ${paletteColors.brand[500]}`
-        }
-      },
-      MuiTabs: {
-        indicator: {
-          backgroundColor: paletteColors.brand[500],
-          height: '4px'
-        }
+        borderColor: paletteColors.neutral[100]
+      }
+    },
+    MuiTableCell: {
+      body: {
+        borderBottomColor: paletteColors.neutral[100]
+      }
+    },
+    MuiTableFooter: {
+      root: {
+        '& th,td': {
+          fontWeight: 'bold',
+          color: text.primary
+        },
+        borderTop: `2px solid ${paletteColors.brand[500]}`,
+        borderBottom: `2px solid ${paletteColors.brand[500]}`
+      }
+    },
+    MuiTabs: {
+      indicator: {
+        backgroundColor: paletteColors.brand[500],
+        height: '4px'
       }
     }
   }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -77,7 +77,11 @@ export const defaultPaletteColors = {
   ...allColors,
   brand: allColors.committedYellow,
   primary: allColors.committedGrey,
-  secondary: allColors.committedYellow,
+  secondary: {
+    '300': allColors.committedYellow[50],
+    '500': allColors.committedYellow[200],
+    '700': allColors.committedYellow[400]
+  },
   success: allColors.teal,
   warning: allColors.orange,
   error: allColors.red,
@@ -125,10 +129,10 @@ export const createLightOptions = (paletteColors: PaletteColors) => {
         contrastText: paletteColors.brand[500]
       },
       secondary: {
-        light: paletteColors.brand[50],
-        main: paletteColors.brand[200],
-        dark: paletteColors.brand[400],
         contrastText: paletteColors.primary[500]
+        light: paletteColors.secondary[300],
+        main: paletteColors.secondary[500],
+        dark: paletteColors.secondary[700]
       },
       error: paletteColors.error,
       success: {

--- a/src/theme/themeMaterialUtil.ts
+++ b/src/theme/themeMaterialUtil.ts
@@ -1,0 +1,14 @@
+import { SimplePaletteColorOptions } from '@material-ui/core/styles'
+
+import createPalette from '@material-ui/core/styles/createPalette'
+import { PaletteColor } from '@material-ui/core/styles/createPalette'
+import { Color } from '@material-ui/core'
+
+// See https://github.com/mui-org/material-ui/blob/b527c91285bcf5a4df49da26fc2800eca8200232/packages/material-ui/src/styles/createPalette.js
+export function augmentColor(
+  color: SimplePaletteColorOptions | Partial<Color> | undefined,
+  defaultColor: SimplePaletteColorOptions | Partial<Color>
+): PaletteColor {
+  const palette = createPalette({ primary: color || defaultColor })
+  return palette.primary
+}

--- a/src/theme/themeProvider.stories.mdx
+++ b/src/theme/themeProvider.stories.mdx
@@ -1,8 +1,17 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks'
-import { Box, Button, Heading, Text, Typography, Display, Monospace } from '../'
+import { Box, Button, Heading, Text, Typography, Display, Monospace,  Chip, Flex, Avatar, Icons } from '../'
 import { ThemeProvider, ThemeProviderDocs } from './ThemeProvider'
 import cyan from '@material-ui/core/colors/cyan'
 import blueGrey from '@material-ui/core/colors/blueGrey'
+import {
+  PaletteColor,
+  PaletteOptions
+} from '@material-ui/core/styles/createPalette'
+import { createMuiTheme } from '@material-ui/core'
+import { Background } from '../util'
+import commmitImage from '../../public/images/Avatar1-YellowTrans-32px.png'
+import * as C from '../'
+import deepmerge from 'deepmerge'
 
 <Meta title="components|ThemeProvider" component={ThemeProvider} />
 
@@ -53,6 +62,808 @@ Custom palette colours can be specified. For example, the primary, secondary or 
       <Button color="primary">Custom Colours</Button>
     </ThemeProvider>
   </Story>
+</Preview>
+
+An Example of custom theming, with blue and yellow colours:
+
+export const paletteOptions = {
+  primary: {
+    //blue
+    light: '#4f83cc',
+    main: '#01579b',
+    dark: '#002f6c',
+    contrastText: '#fff'
+  },
+    brand: {
+    //blue
+    light: '#4f83cc',
+    main: '#01579b',
+    dark: '#002f6c',
+    contrastText: '#fff'
+  },
+  secondary: {
+    //yellow
+    light: '#ffff6b',
+    main: '#fdd835',
+    dark: '#c6a700',
+    contrastText: '#000'
+  }
+}
+
+
+export const createOverrides = (palette) => deepmerge(C.theme.createCommittedOverrides(palette),  {
+    MuiButton: {
+      outlinedSecondary: {
+        color: 'white',
+        borderColor: palette.primary.main
+      },
+    }
+  })
+
+<Preview>
+  <Story name="custom-theming">
+  <C.ThemeProvider style={{ width: '100%', height: '100%', border: '1px' }} createPaletteOptions={() =>
+   paletteOptions} createOverrides={createOverrides}>
+    <Background width="1VH">
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-button--default-story">
+          Buttons
+        </C.Link>
+      </C.Caption>
+      <C.Column flexWrap="wrap">
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          m={1}
+          justifyContent="space-evenly"
+          border="1px solid black"
+        >
+          <C.Column>
+            <C.Button m={3}>Default</C.Button>
+            <C.Button m={3} color="primary">
+              Primary
+            </C.Button>
+            <C.Button m={3} color="secondary">
+              Secondary
+            </C.Button>
+          </C.Column>
+          <C.Column>
+            <C.Button m={3} variant="outlined">
+              Default
+            </C.Button>
+            <C.Button m={3} variant="outlined" color="primary">
+              Primary
+            </C.Button>
+            <C.Button m={3} variant="outlined" color="secondary">
+              Secondary
+            </C.Button>
+          </C.Column>
+          <C.Column>
+            <C.Button m={3} variant="text">
+              Default
+            </C.Button>
+            <C.Button m={3} variant="text" color="primary">
+              Primary
+            </C.Button>
+            <C.Button m={3} variant="text" color="secondary">
+              Secondary
+            </C.Button>
+          </C.Column>
+          <C.Column>
+            <C.Button disabled={true} m={3}>
+              Default
+            </C.Button>
+            <C.Button disabled={true} m={3} color="primary">
+              Primary
+            </C.Button>
+            <C.Button disabled={true} m={3} color="secondary">
+              Secondary
+            </C.Button>
+          </C.Column>
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-iconbutton--default-story">
+            Icon Buttons
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          m={1}
+          justifyContent="space-evenly"
+          border="1px solid black"
+          bgcolor="background.default"
+        >
+          <C.IconButton aria-label="delete">
+            <C.Icons.Delete />
+          </C.IconButton>
+          <C.IconButton aria-label="delete" disabled color="primary">
+            <C.Icons.Delete />
+          </C.IconButton>
+          <C.IconButton color="secondary" aria-label="add an alarm">
+            <C.Icons.Alarm />
+          </C.IconButton>
+          <C.IconButton color="primary" aria-label="add to shopping cart">
+            <C.Icons.AddShoppingCart />
+          </C.IconButton>
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-badge--default-story">
+            Badges
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          pt={4}
+          m={1}
+          justifyContent="space-evenly"
+          border="1px solid black"
+          bgcolor="background.default"
+        >
+          <C.Badge badgeContent={'default'}>
+            <C.IconButton>
+              <C.Icons.Mail />
+            </C.IconButton>
+          </C.Badge>
+          <C.Badge color="primary" badgeContent={4}>
+            <C.IconButton>
+              <C.Icons.Mail />
+            </C.IconButton>
+          </C.Badge>
+          <C.Badge color="secondary" badgeContent={87}>
+            <C.IconButton>
+              <C.Icons.Mail />
+            </C.IconButton>
+          </C.Badge>
+          <C.Badge color="error" badgeContent={1000}>
+            <C.IconButton>
+              <C.Icons.Mail />
+            </C.IconButton>
+          </C.Badge>
+        </C.Flex>
+      </C.Column>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-avatar--default-story">
+          Avatars
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        p={3}
+        pt={4}
+        m={1}
+        justifyContent="space-evenly"
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        <C.Avatar m={1} bgcolor="primary.main" color="primary.contrastText">
+          CF
+        </C.Avatar>
+        <C.Avatar m={1} bgcolor="secondary.main" color="secondary.contrastText">
+          SH
+        </C.Avatar>
+        <C.Avatar m={1}>
+          <C.Icons.Folder />
+        </C.Avatar>
+        <C.Avatar m={1} bgcolor="black" color="white">
+          <C.Icons.Pageview />
+        </C.Avatar>
+        <C.Avatar m={1} bgcolor="primary.light" color="text.primary">
+          <C.Icons.Assignment />
+        </C.Avatar>
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-chip--default-story">
+          Chips
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        p={3}
+        m={1}
+        justifyContent="space-evenly"
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        <C.Chip
+          avatar={<C.Avatar src={commmitImage} />}
+          label="Chip"
+          onDelete={() => {}}
+        />
+        <C.Chip label="Chip" />
+        <C.Chip
+          icon={<C.Icons.Face />}
+          label="Chip"
+          onClick={() => {}}
+          onDelete={() => {}}
+          color="primary"
+        />
+        <C.Chip
+          variant="outlined"
+          icon={<C.Icons.AccountCircle />}
+          label="Chip"
+          onClick={() => {}}
+          color="secondary"
+        />
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-textfield--simple">
+          Text Fields
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        p={3}
+        pt={4}
+        m={1}
+        justifyContent="space-evenly"
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        {React.createElement(() => {
+          const currencies = [
+            {
+              value: 'USD',
+              label: '$'
+            },
+            {
+              value: 'EUR',
+              label: '€'
+            },
+            {
+              value: 'BTC',
+              label: '฿'
+            },
+            {
+              value: 'JPY',
+              label: '¥'
+            }
+          ]
+          const [values, setValues] = React.useState({
+            name: 'Cat in the Hat',
+            age: '',
+            multiline: 'Controlled',
+            currency: 'EUR'
+          })
+          const handleChange = name => event =>
+            setValues({ ...values, [name]: event.target.value })
+          return (
+            <C.Form noValidate autoComplete="off">
+              <C.Flex flexWrap="wrap" alignContent="space-between">
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-name"
+                  label="Name"
+                  value={values.name}
+                  onChange={handleChange('name')}
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-uncontrolled"
+                  label="Uncontrolled"
+                  defaultValue="foo"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  required
+                  id="standard-required"
+                  label="Required"
+                  defaultValue="Hello World"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  error
+                  id="standard-error"
+                  label="Error"
+                  defaultValue="Hello World"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  disabled
+                  id="standard-disabled"
+                  label="Disabled"
+                  defaultValue="Hello World"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-password-input"
+                  label="Password"
+                  type="password"
+                  autoComplete="current-password"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-multiline-flexible"
+                  label="Multiline"
+                  multiline
+                  rowsMax="4"
+                  value={values.multiline}
+                  onChange={handleChange('multiline')}
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-multiline-static"
+                  label="Multiline"
+                  multiline
+                  rows="4"
+                  defaultValue="Default Value"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-read-only-input"
+                  label="Read Only"
+                  defaultValue="Hello World"
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-helperText"
+                  label="Helper text"
+                  defaultValue="Default Value"
+                  helperText="Some important text"
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-number"
+                  label="Number"
+                  value={values.age}
+                  onChange={handleChange('age')}
+                  type="number"
+                  InputLabelProps={{
+                    shrink: true
+                  }}
+                />
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-select-currency"
+                  select
+                  label="Select"
+                  value={values.currency}
+                  onChange={handleChange('currency')}
+                  helperText="Please select your currency"
+                >
+                  {currencies.map(option => (
+                    <C.MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </C.MenuItem>
+                  ))}
+                </C.TextField>
+                <C.TextField
+                  flexGrow={1}
+                  m={3}
+                  id="standard-select-currency-native"
+                  select
+                  label="Native select"
+                  value={values.currency}
+                  onChange={handleChange('currency')}
+                  SelectProps={{
+                    native: true
+                  }}
+                  helperText="Please select your currency"
+                >
+                  {currencies.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </C.TextField>
+              </C.Flex>
+            </C.Form>
+          )
+        })}
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-checkbox--default-story">
+          Checkbox
+        </C.Link>
+        , <C.Link href="/components/?path=/docs/components-radio--default-story">
+          Radio
+        </C.Link> and <C.Link href="/components/?path=/docs/components-switch--default-story">Switch</C.Link>
+      </C.Caption>
+      {React.createElement(() => {
+        const [checked, setChecked] = React.useState(true)
+        return (
+          <C.Flex
+            flexGrow={1}
+            p={3}
+            pt={4}
+            m={1}
+            justifyContent="space-evenly"
+            border="1px solid black"
+            bgcolor="background.defaul"
+          >
+            <C.Column justifyContent="center">
+              <C.Checkbox
+                checked={checked}
+                onChange={event => setChecked(event.target.checked)}
+                color="primary"
+              />
+              <C.Checkbox
+                checked={!checked}
+                onChange={event => setChecked(!event.target.checked)}
+                color="secondary"
+              />
+            </C.Column>
+            <C.Column justifyContent="center">
+              <C.Radio
+                checked={checked}
+                onChange={event => setChecked(event.target.checked)}
+                color="primary"
+              />
+              <C.Radio
+                checked={!checked}
+                onChange={event => setChecked(!event.target.checked)}
+                color="secondary"
+              />
+            </C.Column>
+            <C.Column justifyContent="center">
+              <C.Switch
+                checked={checked}
+                onChange={event => setChecked(event.target.checked)}
+                color="primary"
+              />
+              <C.Switch
+                checked={!checked}
+                onChange={event => setChecked(!event.target.checked)}
+                color="secondary"
+              />
+            </C.Column>
+          </C.Flex>
+        )
+      })}
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-slider--default-story">
+          Slider
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        flexDirection="column"
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        <C.Slider m={3} flexGrow={1} aria-labelledby="continuous-slider" />
+        <C.Slider
+          m={3}
+          flexGrow={1}
+          defaultValue={80}
+          step={10}
+          valueLabelDisplay="on"
+        />
+        <C.Slider m={3} flexGrow={1} value={30} disabled={true} />
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-list--default-story">
+          Lists
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        flexDirection="column"
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        <C.Box minWidth={500} m={3} bgcolor="background.paper">
+          <C.List component="nav" aria-label="main mailbox folders">
+            <C.ListItem button>
+              <C.ListItemIcon>
+                <C.Icons.Inbox />
+              </C.ListItemIcon>
+              <C.ListItemText primary="Inbox" />
+            </C.ListItem>
+            <C.ListItem button>
+              <C.ListItemIcon>
+                <C.Icons.Drafts />
+              </C.ListItemIcon>
+              <C.ListItemText primary="Drafts" />
+            </C.ListItem>
+          </C.List>
+          <Divider />
+          <C.List component="nav" aria-label="secondary mailbox folders">
+            <C.ListItem button>
+              <C.ListItemText primary="Trash" />
+            </C.ListItem>
+            <C.ListItem button>
+              <C.ListItemText primary="Spam" />
+            </C.ListItem>
+          </C.List>
+        </C.Box>
+      </C.Flex>
+      <C.Flex
+        flexGrow={1}
+        flexDirection="column"
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        <C.Box minWidth={500} m={3} bgcolor="background.paper">
+          <C.List>
+            {['18 June 2014', '20 July 2015', '3 January 2018'].map(
+              (item, index) => (
+                <C.ListItem key={index} role={undefined} dense button>
+                  <C.ListItemIcon>
+                    <C.Checkbox
+                      edge="start"
+                      tabIndex={-1}
+                      disableRipple
+                      inputProps={{
+                        'aria-labelledby': 1
+                      }}
+                    />
+                  </C.ListItemIcon>
+                  <C.ListItemText
+                    id={index}
+                    primary={`Line item ${index + 1}`}
+                    secondary={item}
+                  />
+                  <C.ListItemSecondaryAction>
+                    <C.IconButton edge="end">
+                      <C.Icons.Comment />
+                    </C.IconButton>
+                  </C.ListItemSecondaryAction>
+                </C.ListItem>
+              )
+            )}
+          </C.List>
+        </C.Box>
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-card--default-story">
+          Cards
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        flexWrap="wrap"
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.defaul"
+      >
+        <C.Card m={3} width={1 / 2}>
+          <C.Box height={100} bgcolor="primary.main" />
+          <C.CardHeader bgcolor="primary.main" color="primary.contrastText">
+            Committed Card
+          </C.CardHeader>
+          <C.CardContent>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Id nibh
+            tortor id aliquet lectus. Feugiat nibh sed pulvinar proin gravida
+            hendrerit lectus. Facilisis magna etiam tempor orci eu lobortis
+            elementum.
+          </C.CardContent>
+          <C.CardActions>
+            <C.Button color="primary" variant="text">
+              Yes
+            </C.Button>
+            <C.Button color="primary" variant="text">
+              No
+            </C.Button>
+          </C.CardActions>
+        </C.Card>
+        <C.Card m={3} width={1 / 2}>
+          <C.CardHeader bgcolor="secondary.main" color="secondary.contrastText">
+            Card
+          </C.CardHeader>
+          <C.CardActions>
+            <C.Checkbox
+              icon={
+                <C.Icons.FavoriteBorder style={{ color: C.colors.grey[600] }} />
+              }
+              checkedIcon={<C.Icons.Favorite style={{ color: 'red' }} />}
+            />
+            <C.Checkbox
+              icon={
+                <C.Icons.BookmarkBorder style={{ color: C.colors.grey[600] }} />
+              }
+              checkedIcon={
+                <C.Icons.Bookmark style={{ color: C.colors.lightBlue[400] }} />
+              }
+            />
+            <C.IconButton>
+              <C.Icons.Share />
+            </C.IconButton>
+          </C.CardActions>
+        </C.Card>
+        <C.Card>
+          <C.Flex>
+            <C.CardContent>
+              <C.Heading.h5 mb={1}>Title</C.Heading.h5>
+              <C.Subheading.h5
+                mt={0}
+                mb={2}
+                variant="subtitle1"
+                color="textSecondary"
+              >
+                Subtitle
+              </C.Subheading.h5>
+              <C.Flex alignItems="center" p={3}>
+                <C.IconButton size="small">
+                  <C.Icons.SkipPrevious fontSize="small" />
+                </C.IconButton>
+                <C.IconButton>
+                  <C.Icons.PlayArrow fontSize="large" />
+                </C.IconButton>
+                <C.IconButton size="small">
+                  <C.Icons.SkipNext fontSize="small" />
+                </C.IconButton>
+              </C.Flex>
+            </C.CardContent>
+            <C.CardMedia
+              width="200px"
+              height="200px"
+              image="https://picsum.photos/id/645/200/200"
+              title="Picsum"
+            />
+          </C.Flex>
+        </C.Card>
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-table--default-story">
+          Tables
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        flexDirection="column"
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.default"
+      >
+        <C.Box m={2} p={3} bgcolor="background.paper">
+          <C.Table>
+            <C.TableHead>
+              <C.TableRow>
+                <C.TableCell>Dessert (100g serving)</C.TableCell>
+                <C.TableCell align="right">Calories</C.TableCell>
+                <C.TableCell align="right">Fat&nbsp;(g)</C.TableCell>
+                <C.TableCell align="right">Carbs&nbsp;(g)</C.TableCell>
+                <C.TableCell align="right">Protein&nbsp;(g)</C.TableCell>
+              </C.TableRow>
+            </C.TableHead>
+            <C.TableBody>
+              {[
+                ['Frozen yoghurt', 159, 6.0, 24, 4.0],
+                ['Ice cream sandwich', 237, 9.0, 37, 4.3],
+                ['Eclair', 262, 16.0, 24, 6.0],
+                ['Cupcake', 305, 3.7, 67, 4.3],
+                ['Gingerbread', 356, 16.0, 49, 3]
+              ].map(row => (
+                <C.TableRow key={row[0]}>
+                  <C.TableCell component="th" scope="row">
+                    {row[0]}
+                  </C.TableCell>
+                  <C.TableCell align="right">{row[1]}</C.TableCell>
+                  <C.TableCell align="right">{row[2]}</C.TableCell>
+                  <C.TableCell align="right">{row[3]}</C.TableCell>
+                  <C.TableCell align="right">{row[4]}</C.TableCell>
+                </C.TableRow>
+              ))}
+            </C.TableBody>
+          </C.Table>
+        </C.Box>
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/components-tabs--appbar">Tabs</C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        flexDirection="column"
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.default"
+      >
+        {React.createElement(() => {
+          const [value, setValue] = React.useState(0)
+          function handleChange(event, newValue) {
+            setValue(newValue)
+          }
+          return (
+            <C.Box>
+              <C.AppBar position="static">
+                <C.Tabs
+                  value={value}
+                  onChange={handleChange}
+                  aria-label="simple tabs example"
+                >
+                  <C.Tab label="Item One" />
+                  <C.Tab label="Item Two" />
+                  <C.Tab label="Item Three" />
+                </C.Tabs>
+              </C.AppBar>
+              <C.TabPanel p={3} selected={value} index={0}>
+                Item One
+              </C.TabPanel>
+              <C.TabPanel p={3} selected={value} index={1}>
+                Item Two
+              </C.TabPanel>
+              <C.TabPanel p={3} selected={value} index={2}>
+                Item Three
+              </C.TabPanel>
+            </C.Box>
+          )
+        })}
+      </C.Flex>
+      <C.Caption>
+        <C.Link href="/components/?path=/docs/design-system-typography--typography">
+          Typography
+        </C.Link>
+      </C.Caption>
+      <C.Flex
+        flexGrow={1}
+        p={3}
+        pt={4}
+        m={1}
+        border="1px solid black"
+        bgcolor="background.default"
+      >
+        <C.Box width={1 / 2}>
+          <C.Typography>System Typography</C.Typography>
+          <C.Heading.h2 gutterBottom>h2. Heading</C.Heading.h2>
+          <C.Heading.h3 gutterBottom>h3. Heading</C.Heading.h3>
+          <C.Heading.h4 gutterBottom>h4. Heading</C.Heading.h4>
+          <C.Subheading.h3 gutterBottom>
+            subheading. Lorem ipsum dolor sit amet, consectetur adipisicing
+            elit. Quos blanditiis tenetur
+          </C.Subheading.h3>
+          <C.Typography variant="body1" gutterBottom>
+            body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+            consectetur.
+          </C.Typography>
+          <C.Typography variant="body2" gutterBottom>
+            body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+            consectetur.
+          </C.Typography>
+        </C.Box>
+        <C.Box width={1 / 2}>
+          <C.Text>Disply Typography</C.Text>
+          <C.Display.d1 gutterBottom>d1. Heading</C.Display.d1>
+          <C.Display.d2 gutterBottom>d2. Heading</C.Display.d2>
+          <C.Text gutterBottom>
+            Text. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
+            blanditiis tenetur unde suscipit, quam beatae rerum inventore
+            consectetur.
+          </C.Text>
+          <C.Monospace wrap>
+            Monospace. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+            consectetur.
+          </C.Monospace>
+        </C.Box>
+      </C.Flex>
+    </Background>
+  </C.ThemeProvider>
+</Story>
 </Preview>
 
 ## Props

--- a/src/theme/themeProvider.stories.mdx
+++ b/src/theme/themeProvider.stories.mdx
@@ -1,5 +1,17 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks'
-import { Box, Button, Heading, Text, Typography, Display, Monospace,  Chip, Flex, Avatar, Icons } from '../'
+import {
+  Box,
+  Button,
+  Heading,
+  Text,
+  Typography,
+  Display,
+  Monospace,
+  Chip,
+  Flex,
+  Avatar,
+  Icons
+} from '../'
 import { ThemeProvider, ThemeProviderDocs } from './ThemeProvider'
 import cyan from '@material-ui/core/colors/cyan'
 import blueGrey from '@material-ui/core/colors/blueGrey'
@@ -28,7 +40,6 @@ but others can be used if necessary.
 </ThemeProvider>
 ```
 
-
 Custom font stacks can be provided for different typography components. You may need to separately load your font, using imports, links or css; see [example](https://github.com/commitd/components/tree/master/example).
 We recommend using [typefaces](https://github.com/KyleAMathews/typefaces)
 
@@ -56,9 +67,7 @@ Custom palette colours can be specified. For example, the primary, secondary or 
 
 <Preview>
   <Story name="colors">
-    <ThemeProvider
-      paletteColors={{primary: blueGrey, brand: cyan}}
-    >
+    <ThemeProvider paletteColors={{ primary: blueGrey, brand: cyan }}>
       <Button color="primary">Custom Colours</Button>
     </ThemeProvider>
   </Story>
@@ -66,130 +75,192 @@ Custom palette colours can be specified. For example, the primary, secondary or 
 
 An Example of custom theming, with blue and yellow colours:
 
-export const paletteOptions = {
-  primary: {
-    //blue
-    light: '#4f83cc',
-    main: '#01579b',
-    dark: '#002f6c',
-    contrastText: '#fff'
-  },
-    brand: {
-    //blue
-    light: '#4f83cc',
-    main: '#01579b',
-    dark: '#002f6c',
-    contrastText: '#fff'
-  },
-  secondary: {
-    //yellow
-    light: '#ffff6b',
-    main: '#fdd835',
-    dark: '#c6a700',
-    contrastText: '#000'
-  }
-}
-
-
-export const createOverrides = (palette) => deepmerge(C.theme.createCommittedOverrides(palette),  {
-    MuiButton: {
-      outlinedSecondary: {
-        color: 'white',
-        borderColor: palette.primary.main
-      },
-    }
-  })
-
 <Preview>
   <Story name="custom-theming">
-  <C.ThemeProvider style={{ width: '100%', height: '100%', border: '1px' }} createPaletteOptions={() =>
-   paletteOptions} createOverrides={createOverrides}>
-    <Background width="1VH">
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-button--default-story">
-          Buttons
-        </C.Link>
-      </C.Caption>
-      <C.Column flexWrap="wrap">
-        <C.Flex
-          flexGrow={1}
-          p={3}
-          m={1}
-          justifyContent="space-evenly"
-          border="1px solid black"
-        >
-          <C.Column>
-            <C.Button m={3}>Default</C.Button>
-            <C.Button m={3} color="primary">
-              Primary
-            </C.Button>
-            <C.Button m={3} color="secondary">
-              Secondary
-            </C.Button>
-          </C.Column>
-          <C.Column>
-            <C.Button m={3} variant="outlined">
-              Default
-            </C.Button>
-            <C.Button m={3} variant="outlined" color="primary">
-              Primary
-            </C.Button>
-            <C.Button m={3} variant="outlined" color="secondary">
-              Secondary
-            </C.Button>
-          </C.Column>
-          <C.Column>
-            <C.Button m={3} variant="text">
-              Default
-            </C.Button>
-            <C.Button m={3} variant="text" color="primary">
-              Primary
-            </C.Button>
-            <C.Button m={3} variant="text" color="secondary">
-              Secondary
-            </C.Button>
-          </C.Column>
-          <C.Column>
-            <C.Button disabled={true} m={3}>
-              Default
-            </C.Button>
-            <C.Button disabled={true} m={3} color="primary">
-              Primary
-            </C.Button>
-            <C.Button disabled={true} m={3} color="secondary">
-              Secondary
-            </C.Button>
-          </C.Column>
-        </C.Flex>
+    <C.ThemeProvider
+      style={{ width: '100%', height: '100%', border: '1px' }}
+      createPaletteOptions={() => ({
+        primary: {
+          //blue
+          light: '#4f83cc',
+          main: '#01579b',
+          dark: '#002f6c',
+          contrastText: '#fff'
+        },
+        brand: {
+          //blue
+          light: '#4f83cc',
+          main: '#01579b',
+          dark: '#002f6c',
+          contrastText: '#fff'
+        },
+        secondary: {
+          //yellow
+          light: '#ffff6b',
+          main: '#fdd835',
+          dark: '#c6a700',
+          contrastText: '#000'
+        }
+      })}
+      createFonts={() => {
+        const fontFamily = 'Rockwell, sans-serif'
+        return {
+          typography: { fontFamily },
+          heading: { fontFamily },
+          subheading: { fontFamily },
+          text: { fontFamily },
+          display: {
+            fontFamily
+          },
+          monospace: {
+            fontFamily
+          }
+        }
+      }}
+      createShape={() => ({
+        borderRadius: 0
+      })}
+      createSpacing={() => factor => factor * 3}
+      createTypography={() => ({
+        htmlFontSize: 16,
+        fontSize: 20,
+        h1: {
+          fontSize: '1.2rem'
+        }
+      })}
+      createOverrides={palette =>
+        deepmerge(C.theme.createCommittedOverrides(palette), {
+          MuiButton: {
+            outlinedSecondary: {
+              color: 'white',
+              borderColor: palette.primary.main
+            }
+          }
+        })
+      }
+    >
+      <Background width="1VH">
         <C.Caption>
-          <C.Link href="/components/?path=/docs/components-iconbutton--default-story">
-            Icon Buttons
+          <C.Link href="/components/?path=/docs/components-button--default-story">
+            Buttons
           </C.Link>
         </C.Caption>
-        <C.Flex
-          flexGrow={1}
-          p={3}
-          m={1}
-          justifyContent="space-evenly"
-          border="1px solid black"
-          bgcolor="background.default"
-        >
-          <C.IconButton aria-label="delete">
-            <C.Icons.Delete />
-          </C.IconButton>
-          <C.IconButton aria-label="delete" disabled color="primary">
-            <C.Icons.Delete />
-          </C.IconButton>
-          <C.IconButton color="secondary" aria-label="add an alarm">
-            <C.Icons.Alarm />
-          </C.IconButton>
-          <C.IconButton color="primary" aria-label="add to shopping cart">
-            <C.Icons.AddShoppingCart />
-          </C.IconButton>
-        </C.Flex>
+        <C.Column flexWrap="wrap">
+          <C.Flex
+            flexGrow={1}
+            p={3}
+            m={1}
+            justifyContent="space-evenly"
+            border="1px solid black"
+          >
+            <C.Column>
+              <C.Button m={3}>Default</C.Button>
+              <C.Button m={3} color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+            <C.Column>
+              <C.Button m={3} variant="outlined">
+                Default
+              </C.Button>
+              <C.Button m={3} variant="outlined" color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} variant="outlined" color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+            <C.Column>
+              <C.Button m={3} variant="text">
+                Default
+              </C.Button>
+              <C.Button m={3} variant="text" color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} variant="text" color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+            <C.Column>
+              <C.Button disabled={true} m={3}>
+                Default
+              </C.Button>
+              <C.Button disabled={true} m={3} color="primary">
+                Primary
+              </C.Button>
+              <C.Button disabled={true} m={3} color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+          </C.Flex>
+          <C.Caption>
+            <C.Link href="/components/?path=/docs/components-iconbutton--default-story">
+              Icon Buttons
+            </C.Link>
+          </C.Caption>
+          <C.Flex
+            flexGrow={1}
+            p={3}
+            m={1}
+            justifyContent="space-evenly"
+            border="1px solid black"
+            bgcolor="background.default"
+          >
+            <C.IconButton aria-label="delete">
+              <C.Icons.Delete />
+            </C.IconButton>
+            <C.IconButton aria-label="delete" disabled color="primary">
+              <C.Icons.Delete />
+            </C.IconButton>
+            <C.IconButton color="secondary" aria-label="add an alarm">
+              <C.Icons.Alarm />
+            </C.IconButton>
+            <C.IconButton color="primary" aria-label="add to shopping cart">
+              <C.Icons.AddShoppingCart />
+            </C.IconButton>
+          </C.Flex>
+          <C.Caption>
+            <C.Link href="/components/?path=/docs/components-badge--default-story">
+              Badges
+            </C.Link>
+          </C.Caption>
+          <C.Flex
+            flexGrow={1}
+            p={3}
+            pt={4}
+            m={1}
+            justifyContent="space-evenly"
+            border="1px solid black"
+            bgcolor="background.default"
+          >
+            <C.Badge badgeContent={'default'}>
+              <C.IconButton>
+                <C.Icons.Mail />
+              </C.IconButton>
+            </C.Badge>
+            <C.Badge color="primary" badgeContent={4}>
+              <C.IconButton>
+                <C.Icons.Mail />
+              </C.IconButton>
+            </C.Badge>
+            <C.Badge color="secondary" badgeContent={87}>
+              <C.IconButton>
+                <C.Icons.Mail />
+              </C.IconButton>
+            </C.Badge>
+            <C.Badge color="error" badgeContent={1000}>
+              <C.IconButton>
+                <C.Icons.Mail />
+              </C.IconButton>
+            </C.Badge>
+          </C.Flex>
+        </C.Column>
         <C.Caption>
-          <C.Link href="/components/?path=/docs/components-badge--default-story">
-            Badges
+          <C.Link href="/components/?path=/docs/components-avatar--default-story">
+            Avatars
           </C.Link>
         </C.Caption>
         <C.Flex
@@ -199,671 +270,650 @@ export const createOverrides = (palette) => deepmerge(C.theme.createCommittedOve
           m={1}
           justifyContent="space-evenly"
           border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          <C.Avatar m={1} bgcolor="primary.main" color="primary.contrastText">
+            CF
+          </C.Avatar>
+          <C.Avatar
+            m={1}
+            bgcolor="secondary.main"
+            color="secondary.contrastText"
+          >
+            SH
+          </C.Avatar>
+          <C.Avatar m={1}>
+            <C.Icons.Folder />
+          </C.Avatar>
+          <C.Avatar m={1} bgcolor="black" color="white">
+            <C.Icons.Pageview />
+          </C.Avatar>
+          <C.Avatar m={1} bgcolor="primary.light" color="text.primary">
+            <C.Icons.Assignment />
+          </C.Avatar>
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-chip--default-story">
+            Chips
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          m={1}
+          justifyContent="space-evenly"
+          border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          <C.Chip
+            avatar={<C.Avatar src={commmitImage} />}
+            label="Chip"
+            onDelete={() => {}}
+          />
+          <C.Chip label="Chip" />
+          <C.Chip
+            icon={<C.Icons.Face />}
+            label="Chip"
+            onClick={() => {}}
+            onDelete={() => {}}
+            color="primary"
+          />
+          <C.Chip
+            variant="outlined"
+            icon={<C.Icons.AccountCircle />}
+            label="Chip"
+            onClick={() => {}}
+            color="secondary"
+          />
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-textfield--simple">
+            Text Fields
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          pt={4}
+          m={1}
+          justifyContent="space-evenly"
+          border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          {React.createElement(() => {
+            const currencies = [
+              {
+                value: 'USD',
+                label: '$'
+              },
+              {
+                value: 'EUR',
+                label: '€'
+              },
+              {
+                value: 'BTC',
+                label: '฿'
+              },
+              {
+                value: 'JPY',
+                label: '¥'
+              }
+            ]
+            const [values, setValues] = React.useState({
+              name: 'Cat in the Hat',
+              age: '',
+              multiline: 'Controlled',
+              currency: 'EUR'
+            })
+            const handleChange = name => event =>
+              setValues({ ...values, [name]: event.target.value })
+            return (
+              <C.Form noValidate autoComplete="off">
+                <C.Flex flexWrap="wrap" alignContent="space-between">
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-name"
+                    label="Name"
+                    value={values.name}
+                    onChange={handleChange('name')}
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-uncontrolled"
+                    label="Uncontrolled"
+                    defaultValue="foo"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    required
+                    id="standard-required"
+                    label="Required"
+                    defaultValue="Hello World"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    error
+                    id="standard-error"
+                    label="Error"
+                    defaultValue="Hello World"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    disabled
+                    id="standard-disabled"
+                    label="Disabled"
+                    defaultValue="Hello World"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-password-input"
+                    label="Password"
+                    type="password"
+                    autoComplete="current-password"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-multiline-flexible"
+                    label="Multiline"
+                    multiline
+                    rowsMax="4"
+                    value={values.multiline}
+                    onChange={handleChange('multiline')}
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-multiline-static"
+                    label="Multiline"
+                    multiline
+                    rows="4"
+                    defaultValue="Default Value"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-read-only-input"
+                    label="Read Only"
+                    defaultValue="Hello World"
+                    InputProps={{
+                      readOnly: true
+                    }}
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-helperText"
+                    label="Helper text"
+                    defaultValue="Default Value"
+                    helperText="Some important text"
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-number"
+                    label="Number"
+                    value={values.age}
+                    onChange={handleChange('age')}
+                    type="number"
+                    InputLabelProps={{
+                      shrink: true
+                    }}
+                  />
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-select-currency"
+                    select
+                    label="Select"
+                    value={values.currency}
+                    onChange={handleChange('currency')}
+                    helperText="Please select your currency"
+                  >
+                    {currencies.map(option => (
+                      <C.MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </C.MenuItem>
+                    ))}
+                  </C.TextField>
+                  <C.TextField
+                    flexGrow={1}
+                    m={3}
+                    id="standard-select-currency-native"
+                    select
+                    label="Native select"
+                    value={values.currency}
+                    onChange={handleChange('currency')}
+                    SelectProps={{
+                      native: true
+                    }}
+                    helperText="Please select your currency"
+                  >
+                    {currencies.map(option => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </C.TextField>
+                </C.Flex>
+              </C.Form>
+            )
+          })}
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-checkbox--default-story">
+            Checkbox
+          </C.Link>
+          , <C.Link href="/components/?path=/docs/components-radio--default-story">
+            Radio
+          </C.Link> and <C.Link href="/components/?path=/docs/components-switch--default-story">Switch</C.Link>
+        </C.Caption>
+        {React.createElement(() => {
+          const [checked, setChecked] = React.useState(true)
+          return (
+            <C.Flex
+              flexGrow={1}
+              p={3}
+              pt={4}
+              m={1}
+              justifyContent="space-evenly"
+              border="1px solid black"
+              bgcolor="background.defaul"
+            >
+              <C.Column justifyContent="center">
+                <C.Checkbox
+                  checked={checked}
+                  onChange={event => setChecked(event.target.checked)}
+                  color="primary"
+                />
+                <C.Checkbox
+                  checked={!checked}
+                  onChange={event => setChecked(!event.target.checked)}
+                  color="secondary"
+                />
+              </C.Column>
+              <C.Column justifyContent="center">
+                <C.Radio
+                  checked={checked}
+                  onChange={event => setChecked(event.target.checked)}
+                  color="primary"
+                />
+                <C.Radio
+                  checked={!checked}
+                  onChange={event => setChecked(!event.target.checked)}
+                  color="secondary"
+                />
+              </C.Column>
+              <C.Column justifyContent="center">
+                <C.Switch
+                  checked={checked}
+                  onChange={event => setChecked(event.target.checked)}
+                  color="primary"
+                />
+                <C.Switch
+                  checked={!checked}
+                  onChange={event => setChecked(!event.target.checked)}
+                  color="secondary"
+                />
+              </C.Column>
+            </C.Flex>
+          )
+        })}
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-slider--default-story">
+            Slider
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          flexDirection="column"
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          <C.Slider m={3} flexGrow={1} aria-labelledby="continuous-slider" />
+          <C.Slider
+            m={3}
+            flexGrow={1}
+            defaultValue={80}
+            step={10}
+            valueLabelDisplay="on"
+          />
+          <C.Slider m={3} flexGrow={1} value={30} disabled={true} />
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-list--default-story">
+            Lists
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          flexDirection="column"
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          <C.Box minWidth={500} m={3} bgcolor="background.paper">
+            <C.List component="nav" aria-label="main mailbox folders">
+              <C.ListItem button>
+                <C.ListItemIcon>
+                  <C.Icons.Inbox />
+                </C.ListItemIcon>
+                <C.ListItemText primary="Inbox" />
+              </C.ListItem>
+              <C.ListItem button>
+                <C.ListItemIcon>
+                  <C.Icons.Drafts />
+                </C.ListItemIcon>
+                <C.ListItemText primary="Drafts" />
+              </C.ListItem>
+            </C.List>
+            <Divider />
+            <C.List component="nav" aria-label="secondary mailbox folders">
+              <C.ListItem button>
+                <C.ListItemText primary="Trash" />
+              </C.ListItem>
+              <C.ListItem button>
+                <C.ListItemText primary="Spam" />
+              </C.ListItem>
+            </C.List>
+          </C.Box>
+        </C.Flex>
+        <C.Flex
+          flexGrow={1}
+          flexDirection="column"
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          <C.Box minWidth={500} m={3} bgcolor="background.paper">
+            <C.List>
+              {['18 June 2014', '20 July 2015', '3 January 2018'].map(
+                (item, index) => (
+                  <C.ListItem key={index} role={undefined} dense button>
+                    <C.ListItemIcon>
+                      <C.Checkbox
+                        edge="start"
+                        tabIndex={-1}
+                        disableRipple
+                        inputProps={{
+                          'aria-labelledby': 1
+                        }}
+                      />
+                    </C.ListItemIcon>
+                    <C.ListItemText
+                      id={index}
+                      primary={`Line item ${index + 1}`}
+                      secondary={item}
+                    />
+                    <C.ListItemSecondaryAction>
+                      <C.IconButton edge="end">
+                        <C.Icons.Comment />
+                      </C.IconButton>
+                    </C.ListItemSecondaryAction>
+                  </C.ListItem>
+                )
+              )}
+            </C.List>
+          </C.Box>
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-card--default-story">
+            Cards
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          flexWrap="wrap"
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.defaul"
+        >
+          <C.Card m={3} width={1 / 2}>
+            <C.Box height={100} bgcolor="primary.main" />
+            <C.CardHeader bgcolor="primary.main" color="primary.contrastText">
+              Committed Card
+            </C.CardHeader>
+            <C.CardContent>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Id
+              nibh tortor id aliquet lectus. Feugiat nibh sed pulvinar proin
+              gravida hendrerit lectus. Facilisis magna etiam tempor orci eu
+              lobortis elementum.
+            </C.CardContent>
+            <C.CardActions>
+              <C.Button color="primary" variant="text">
+                Yes
+              </C.Button>
+              <C.Button color="primary" variant="text">
+                No
+              </C.Button>
+            </C.CardActions>
+          </C.Card>
+          <C.Card m={3} width={1 / 2}>
+            <C.CardHeader
+              bgcolor="secondary.main"
+              color="secondary.contrastText"
+            >
+              Card
+            </C.CardHeader>
+            <C.CardActions>
+              <C.Checkbox
+                icon={
+                  <C.Icons.FavoriteBorder
+                    style={{ color: C.colors.grey[600] }}
+                  />
+                }
+                checkedIcon={<C.Icons.Favorite style={{ color: 'red' }} />}
+              />
+              <C.Checkbox
+                icon={
+                  <C.Icons.BookmarkBorder
+                    style={{ color: C.colors.grey[600] }}
+                  />
+                }
+                checkedIcon={
+                  <C.Icons.Bookmark
+                    style={{ color: C.colors.lightBlue[400] }}
+                  />
+                }
+              />
+              <C.IconButton>
+                <C.Icons.Share />
+              </C.IconButton>
+            </C.CardActions>
+          </C.Card>
+          <C.Card>
+            <C.Flex>
+              <C.CardContent>
+                <C.Heading.h5 mb={1}>Title</C.Heading.h5>
+                <C.Subheading.h5
+                  mt={0}
+                  mb={2}
+                  variant="subtitle1"
+                  color="textSecondary"
+                >
+                  Subtitle
+                </C.Subheading.h5>
+                <C.Flex alignItems="center" p={3}>
+                  <C.IconButton size="small">
+                    <C.Icons.SkipPrevious fontSize="small" />
+                  </C.IconButton>
+                  <C.IconButton>
+                    <C.Icons.PlayArrow fontSize="large" />
+                  </C.IconButton>
+                  <C.IconButton size="small">
+                    <C.Icons.SkipNext fontSize="small" />
+                  </C.IconButton>
+                </C.Flex>
+              </C.CardContent>
+              <C.CardMedia
+                width="200px"
+                height="200px"
+                image="https://picsum.photos/id/645/200/200"
+                title="Picsum"
+              />
+            </C.Flex>
+          </C.Card>
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-table--default-story">
+            Tables
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          flexDirection="column"
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
           bgcolor="background.default"
         >
-          <C.Badge badgeContent={'default'}>
-            <C.IconButton>
-              <C.Icons.Mail />
-            </C.IconButton>
-          </C.Badge>
-          <C.Badge color="primary" badgeContent={4}>
-            <C.IconButton>
-              <C.Icons.Mail />
-            </C.IconButton>
-          </C.Badge>
-          <C.Badge color="secondary" badgeContent={87}>
-            <C.IconButton>
-              <C.Icons.Mail />
-            </C.IconButton>
-          </C.Badge>
-          <C.Badge color="error" badgeContent={1000}>
-            <C.IconButton>
-              <C.Icons.Mail />
-            </C.IconButton>
-          </C.Badge>
-        </C.Flex>
-      </C.Column>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-avatar--default-story">
-          Avatars
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        p={3}
-        pt={4}
-        m={1}
-        justifyContent="space-evenly"
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        <C.Avatar m={1} bgcolor="primary.main" color="primary.contrastText">
-          CF
-        </C.Avatar>
-        <C.Avatar m={1} bgcolor="secondary.main" color="secondary.contrastText">
-          SH
-        </C.Avatar>
-        <C.Avatar m={1}>
-          <C.Icons.Folder />
-        </C.Avatar>
-        <C.Avatar m={1} bgcolor="black" color="white">
-          <C.Icons.Pageview />
-        </C.Avatar>
-        <C.Avatar m={1} bgcolor="primary.light" color="text.primary">
-          <C.Icons.Assignment />
-        </C.Avatar>
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-chip--default-story">
-          Chips
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        p={3}
-        m={1}
-        justifyContent="space-evenly"
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        <C.Chip
-          avatar={<C.Avatar src={commmitImage} />}
-          label="Chip"
-          onDelete={() => {}}
-        />
-        <C.Chip label="Chip" />
-        <C.Chip
-          icon={<C.Icons.Face />}
-          label="Chip"
-          onClick={() => {}}
-          onDelete={() => {}}
-          color="primary"
-        />
-        <C.Chip
-          variant="outlined"
-          icon={<C.Icons.AccountCircle />}
-          label="Chip"
-          onClick={() => {}}
-          color="secondary"
-        />
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-textfield--simple">
-          Text Fields
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        p={3}
-        pt={4}
-        m={1}
-        justifyContent="space-evenly"
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        {React.createElement(() => {
-          const currencies = [
-            {
-              value: 'USD',
-              label: '$'
-            },
-            {
-              value: 'EUR',
-              label: '€'
-            },
-            {
-              value: 'BTC',
-              label: '฿'
-            },
-            {
-              value: 'JPY',
-              label: '¥'
-            }
-          ]
-          const [values, setValues] = React.useState({
-            name: 'Cat in the Hat',
-            age: '',
-            multiline: 'Controlled',
-            currency: 'EUR'
-          })
-          const handleChange = name => event =>
-            setValues({ ...values, [name]: event.target.value })
-          return (
-            <C.Form noValidate autoComplete="off">
-              <C.Flex flexWrap="wrap" alignContent="space-between">
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-name"
-                  label="Name"
-                  value={values.name}
-                  onChange={handleChange('name')}
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-uncontrolled"
-                  label="Uncontrolled"
-                  defaultValue="foo"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  required
-                  id="standard-required"
-                  label="Required"
-                  defaultValue="Hello World"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  error
-                  id="standard-error"
-                  label="Error"
-                  defaultValue="Hello World"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  disabled
-                  id="standard-disabled"
-                  label="Disabled"
-                  defaultValue="Hello World"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-password-input"
-                  label="Password"
-                  type="password"
-                  autoComplete="current-password"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-multiline-flexible"
-                  label="Multiline"
-                  multiline
-                  rowsMax="4"
-                  value={values.multiline}
-                  onChange={handleChange('multiline')}
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-multiline-static"
-                  label="Multiline"
-                  multiline
-                  rows="4"
-                  defaultValue="Default Value"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-read-only-input"
-                  label="Read Only"
-                  defaultValue="Hello World"
-                  InputProps={{
-                    readOnly: true
-                  }}
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-helperText"
-                  label="Helper text"
-                  defaultValue="Default Value"
-                  helperText="Some important text"
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-number"
-                  label="Number"
-                  value={values.age}
-                  onChange={handleChange('age')}
-                  type="number"
-                  InputLabelProps={{
-                    shrink: true
-                  }}
-                />
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-select-currency"
-                  select
-                  label="Select"
-                  value={values.currency}
-                  onChange={handleChange('currency')}
-                  helperText="Please select your currency"
-                >
-                  {currencies.map(option => (
-                    <C.MenuItem key={option.value} value={option.value}>
-                      {option.label}
-                    </C.MenuItem>
-                  ))}
-                </C.TextField>
-                <C.TextField
-                  flexGrow={1}
-                  m={3}
-                  id="standard-select-currency-native"
-                  select
-                  label="Native select"
-                  value={values.currency}
-                  onChange={handleChange('currency')}
-                  SelectProps={{
-                    native: true
-                  }}
-                  helperText="Please select your currency"
-                >
-                  {currencies.map(option => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </C.TextField>
-              </C.Flex>
-            </C.Form>
-          )
-        })}
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-checkbox--default-story">
-          Checkbox
-        </C.Link>
-        , <C.Link href="/components/?path=/docs/components-radio--default-story">
-          Radio
-        </C.Link> and <C.Link href="/components/?path=/docs/components-switch--default-story">Switch</C.Link>
-      </C.Caption>
-      {React.createElement(() => {
-        const [checked, setChecked] = React.useState(true)
-        return (
-          <C.Flex
-            flexGrow={1}
-            p={3}
-            pt={4}
-            m={1}
-            justifyContent="space-evenly"
-            border="1px solid black"
-            bgcolor="background.defaul"
-          >
-            <C.Column justifyContent="center">
-              <C.Checkbox
-                checked={checked}
-                onChange={event => setChecked(event.target.checked)}
-                color="primary"
-              />
-              <C.Checkbox
-                checked={!checked}
-                onChange={event => setChecked(!event.target.checked)}
-                color="secondary"
-              />
-            </C.Column>
-            <C.Column justifyContent="center">
-              <C.Radio
-                checked={checked}
-                onChange={event => setChecked(event.target.checked)}
-                color="primary"
-              />
-              <C.Radio
-                checked={!checked}
-                onChange={event => setChecked(!event.target.checked)}
-                color="secondary"
-              />
-            </C.Column>
-            <C.Column justifyContent="center">
-              <C.Switch
-                checked={checked}
-                onChange={event => setChecked(event.target.checked)}
-                color="primary"
-              />
-              <C.Switch
-                checked={!checked}
-                onChange={event => setChecked(!event.target.checked)}
-                color="secondary"
-              />
-            </C.Column>
-          </C.Flex>
-        )
-      })}
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-slider--default-story">
-          Slider
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        flexDirection="column"
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        <C.Slider m={3} flexGrow={1} aria-labelledby="continuous-slider" />
-        <C.Slider
-          m={3}
-          flexGrow={1}
-          defaultValue={80}
-          step={10}
-          valueLabelDisplay="on"
-        />
-        <C.Slider m={3} flexGrow={1} value={30} disabled={true} />
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-list--default-story">
-          Lists
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        flexDirection="column"
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        <C.Box minWidth={500} m={3} bgcolor="background.paper">
-          <C.List component="nav" aria-label="main mailbox folders">
-            <C.ListItem button>
-              <C.ListItemIcon>
-                <C.Icons.Inbox />
-              </C.ListItemIcon>
-              <C.ListItemText primary="Inbox" />
-            </C.ListItem>
-            <C.ListItem button>
-              <C.ListItemIcon>
-                <C.Icons.Drafts />
-              </C.ListItemIcon>
-              <C.ListItemText primary="Drafts" />
-            </C.ListItem>
-          </C.List>
-          <Divider />
-          <C.List component="nav" aria-label="secondary mailbox folders">
-            <C.ListItem button>
-              <C.ListItemText primary="Trash" />
-            </C.ListItem>
-            <C.ListItem button>
-              <C.ListItemText primary="Spam" />
-            </C.ListItem>
-          </C.List>
-        </C.Box>
-      </C.Flex>
-      <C.Flex
-        flexGrow={1}
-        flexDirection="column"
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        <C.Box minWidth={500} m={3} bgcolor="background.paper">
-          <C.List>
-            {['18 June 2014', '20 July 2015', '3 January 2018'].map(
-              (item, index) => (
-                <C.ListItem key={index} role={undefined} dense button>
-                  <C.ListItemIcon>
-                    <C.Checkbox
-                      edge="start"
-                      tabIndex={-1}
-                      disableRipple
-                      inputProps={{
-                        'aria-labelledby': 1
-                      }}
-                    />
-                  </C.ListItemIcon>
-                  <C.ListItemText
-                    id={index}
-                    primary={`Line item ${index + 1}`}
-                    secondary={item}
-                  />
-                  <C.ListItemSecondaryAction>
-                    <C.IconButton edge="end">
-                      <C.Icons.Comment />
-                    </C.IconButton>
-                  </C.ListItemSecondaryAction>
-                </C.ListItem>
-              )
-            )}
-          </C.List>
-        </C.Box>
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-card--default-story">
-          Cards
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        flexWrap="wrap"
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.defaul"
-      >
-        <C.Card m={3} width={1 / 2}>
-          <C.Box height={100} bgcolor="primary.main" />
-          <C.CardHeader bgcolor="primary.main" color="primary.contrastText">
-            Committed Card
-          </C.CardHeader>
-          <C.CardContent>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Id nibh
-            tortor id aliquet lectus. Feugiat nibh sed pulvinar proin gravida
-            hendrerit lectus. Facilisis magna etiam tempor orci eu lobortis
-            elementum.
-          </C.CardContent>
-          <C.CardActions>
-            <C.Button color="primary" variant="text">
-              Yes
-            </C.Button>
-            <C.Button color="primary" variant="text">
-              No
-            </C.Button>
-          </C.CardActions>
-        </C.Card>
-        <C.Card m={3} width={1 / 2}>
-          <C.CardHeader bgcolor="secondary.main" color="secondary.contrastText">
-            Card
-          </C.CardHeader>
-          <C.CardActions>
-            <C.Checkbox
-              icon={
-                <C.Icons.FavoriteBorder style={{ color: C.colors.grey[600] }} />
-              }
-              checkedIcon={<C.Icons.Favorite style={{ color: 'red' }} />}
-            />
-            <C.Checkbox
-              icon={
-                <C.Icons.BookmarkBorder style={{ color: C.colors.grey[600] }} />
-              }
-              checkedIcon={
-                <C.Icons.Bookmark style={{ color: C.colors.lightBlue[400] }} />
-              }
-            />
-            <C.IconButton>
-              <C.Icons.Share />
-            </C.IconButton>
-          </C.CardActions>
-        </C.Card>
-        <C.Card>
-          <C.Flex>
-            <C.CardContent>
-              <C.Heading.h5 mb={1}>Title</C.Heading.h5>
-              <C.Subheading.h5
-                mt={0}
-                mb={2}
-                variant="subtitle1"
-                color="textSecondary"
-              >
-                Subtitle
-              </C.Subheading.h5>
-              <C.Flex alignItems="center" p={3}>
-                <C.IconButton size="small">
-                  <C.Icons.SkipPrevious fontSize="small" />
-                </C.IconButton>
-                <C.IconButton>
-                  <C.Icons.PlayArrow fontSize="large" />
-                </C.IconButton>
-                <C.IconButton size="small">
-                  <C.Icons.SkipNext fontSize="small" />
-                </C.IconButton>
-              </C.Flex>
-            </C.CardContent>
-            <C.CardMedia
-              width="200px"
-              height="200px"
-              image="https://picsum.photos/id/645/200/200"
-              title="Picsum"
-            />
-          </C.Flex>
-        </C.Card>
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-table--default-story">
-          Tables
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        flexDirection="column"
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.default"
-      >
-        <C.Box m={2} p={3} bgcolor="background.paper">
-          <C.Table>
-            <C.TableHead>
-              <C.TableRow>
-                <C.TableCell>Dessert (100g serving)</C.TableCell>
-                <C.TableCell align="right">Calories</C.TableCell>
-                <C.TableCell align="right">Fat&nbsp;(g)</C.TableCell>
-                <C.TableCell align="right">Carbs&nbsp;(g)</C.TableCell>
-                <C.TableCell align="right">Protein&nbsp;(g)</C.TableCell>
-              </C.TableRow>
-            </C.TableHead>
-            <C.TableBody>
-              {[
-                ['Frozen yoghurt', 159, 6.0, 24, 4.0],
-                ['Ice cream sandwich', 237, 9.0, 37, 4.3],
-                ['Eclair', 262, 16.0, 24, 6.0],
-                ['Cupcake', 305, 3.7, 67, 4.3],
-                ['Gingerbread', 356, 16.0, 49, 3]
-              ].map(row => (
-                <C.TableRow key={row[0]}>
-                  <C.TableCell component="th" scope="row">
-                    {row[0]}
-                  </C.TableCell>
-                  <C.TableCell align="right">{row[1]}</C.TableCell>
-                  <C.TableCell align="right">{row[2]}</C.TableCell>
-                  <C.TableCell align="right">{row[3]}</C.TableCell>
-                  <C.TableCell align="right">{row[4]}</C.TableCell>
+          <C.Box m={2} p={3} bgcolor="background.paper">
+            <C.Table>
+              <C.TableHead>
+                <C.TableRow>
+                  <C.TableCell>Dessert (100g serving)</C.TableCell>
+                  <C.TableCell align="right">Calories</C.TableCell>
+                  <C.TableCell align="right">Fat&nbsp;(g)</C.TableCell>
+                  <C.TableCell align="right">Carbs&nbsp;(g)</C.TableCell>
+                  <C.TableCell align="right">Protein&nbsp;(g)</C.TableCell>
                 </C.TableRow>
-              ))}
-            </C.TableBody>
-          </C.Table>
-        </C.Box>
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/components-tabs--appbar">Tabs</C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        flexDirection="column"
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.default"
-      >
-        {React.createElement(() => {
-          const [value, setValue] = React.useState(0)
-          function handleChange(event, newValue) {
-            setValue(newValue)
-          }
-          return (
-            <C.Box>
-              <C.AppBar position="static">
-                <C.Tabs
-                  value={value}
-                  onChange={handleChange}
-                  aria-label="simple tabs example"
-                >
-                  <C.Tab label="Item One" />
-                  <C.Tab label="Item Two" />
-                  <C.Tab label="Item Three" />
-                </C.Tabs>
-              </C.AppBar>
-              <C.TabPanel p={3} selected={value} index={0}>
-                Item One
-              </C.TabPanel>
-              <C.TabPanel p={3} selected={value} index={1}>
-                Item Two
-              </C.TabPanel>
-              <C.TabPanel p={3} selected={value} index={2}>
-                Item Three
-              </C.TabPanel>
-            </C.Box>
-          )
-        })}
-      </C.Flex>
-      <C.Caption>
-        <C.Link href="/components/?path=/docs/design-system-typography--typography">
-          Typography
-        </C.Link>
-      </C.Caption>
-      <C.Flex
-        flexGrow={1}
-        p={3}
-        pt={4}
-        m={1}
-        border="1px solid black"
-        bgcolor="background.default"
-      >
-        <C.Box width={1 / 2}>
-          <C.Typography>System Typography</C.Typography>
-          <C.Heading.h2 gutterBottom>h2. Heading</C.Heading.h2>
-          <C.Heading.h3 gutterBottom>h3. Heading</C.Heading.h3>
-          <C.Heading.h4 gutterBottom>h4. Heading</C.Heading.h4>
-          <C.Subheading.h3 gutterBottom>
-            subheading. Lorem ipsum dolor sit amet, consectetur adipisicing
-            elit. Quos blanditiis tenetur
-          </C.Subheading.h3>
-          <C.Typography variant="body1" gutterBottom>
-            body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-            Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
-            consectetur.
-          </C.Typography>
-          <C.Typography variant="body2" gutterBottom>
-            body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-            Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
-            consectetur.
-          </C.Typography>
-        </C.Box>
-        <C.Box width={1 / 2}>
-          <C.Text>Disply Typography</C.Text>
-          <C.Display.d1 gutterBottom>d1. Heading</C.Display.d1>
-          <C.Display.d2 gutterBottom>d2. Heading</C.Display.d2>
-          <C.Text gutterBottom>
-            Text. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
-            blanditiis tenetur unde suscipit, quam beatae rerum inventore
-            consectetur.
-          </C.Text>
-          <C.Monospace wrap>
-            Monospace. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-            Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
-            consectetur.
-          </C.Monospace>
-        </C.Box>
-      </C.Flex>
-    </Background>
-  </C.ThemeProvider>
-</Story>
+              </C.TableHead>
+              <C.TableBody>
+                {[
+                  ['Frozen yoghurt', 159, 6.0, 24, 4.0],
+                  ['Ice cream sandwich', 237, 9.0, 37, 4.3],
+                  ['Eclair', 262, 16.0, 24, 6.0],
+                  ['Cupcake', 305, 3.7, 67, 4.3],
+                  ['Gingerbread', 356, 16.0, 49, 3]
+                ].map(row => (
+                  <C.TableRow key={row[0]}>
+                    <C.TableCell component="th" scope="row">
+                      {row[0]}
+                    </C.TableCell>
+                    <C.TableCell align="right">{row[1]}</C.TableCell>
+                    <C.TableCell align="right">{row[2]}</C.TableCell>
+                    <C.TableCell align="right">{row[3]}</C.TableCell>
+                    <C.TableCell align="right">{row[4]}</C.TableCell>
+                  </C.TableRow>
+                ))}
+              </C.TableBody>
+            </C.Table>
+          </C.Box>
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-tabs--appbar">
+            Tabs
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          flexDirection="column"
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.default"
+        >
+          {React.createElement(() => {
+            const [value, setValue] = React.useState(0)
+            function handleChange(event, newValue) {
+              setValue(newValue)
+            }
+            return (
+              <C.Box>
+                <C.AppBar position="static">
+                  <C.Tabs
+                    value={value}
+                    onChange={handleChange}
+                    aria-label="simple tabs example"
+                  >
+                    <C.Tab label="Item One" />
+                    <C.Tab label="Item Two" />
+                    <C.Tab label="Item Three" />
+                  </C.Tabs>
+                </C.AppBar>
+                <C.TabPanel p={3} selected={value} index={0}>
+                  Item One
+                </C.TabPanel>
+                <C.TabPanel p={3} selected={value} index={1}>
+                  Item Two
+                </C.TabPanel>
+                <C.TabPanel p={3} selected={value} index={2}>
+                  Item Three
+                </C.TabPanel>
+              </C.Box>
+            )
+          })}
+        </C.Flex>
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/design-system-typography--typography">
+            Typography
+          </C.Link>
+        </C.Caption>
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.default"
+        >
+          <C.Box width={1 / 2}>
+            <C.Typography>System Typography</C.Typography>
+            <C.Heading.h2 gutterBottom>h2. Heading</C.Heading.h2>
+            <C.Heading.h3 gutterBottom>h3. Heading</C.Heading.h3>
+            <C.Heading.h4 gutterBottom>h4. Heading</C.Heading.h4>
+            <C.Subheading.h3 gutterBottom>
+              subheading. Lorem ipsum dolor sit amet, consectetur adipisicing
+              elit. Quos blanditiis tenetur
+            </C.Subheading.h3>
+            <C.Typography variant="body1" gutterBottom>
+              body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+              consectetur.
+            </C.Typography>
+            <C.Typography variant="body2" gutterBottom>
+              body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+              consectetur.
+            </C.Typography>
+          </C.Box>
+          <C.Box width={1 / 2}>
+            <C.Text>Disply Typography</C.Text>
+            <C.Display.d1 gutterBottom>d1. Heading</C.Display.d1>
+            <C.Display.d2 gutterBottom>d2. Heading</C.Display.d2>
+            <C.Text gutterBottom>
+              Text. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+              consectetur.
+            </C.Text>
+            <C.Monospace wrap>
+              Monospace. Lorem ipsum dolor sit amet, consectetur adipisicing
+              elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum
+              inventore consectetur.
+            </C.Monospace>
+          </C.Box>
+        </C.Flex>
+      </Background>
+    </C.ThemeProvider>
+  </Story>
 </Preview>
 
 ## Props

--- a/src/theme/themeProvider.stories.mdx
+++ b/src/theme/themeProvider.stories.mdx
@@ -40,17 +40,30 @@ but others can be used if necessary.
 </ThemeProvider>
 ```
 
+## Custom Fonts
+
+The optional `createFonts()` prop should either return a `theme.FontOptions` object to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+
 Custom font stacks can be provided for different typography components. You may need to separately load your font, using imports, links or css; see [example](https://github.com/commitd/components/tree/master/example).
 We recommend using [typefaces](https://github.com/KyleAMathews/typefaces)
 
 <Preview>
   <Story name="default">
     <ThemeProvider
-      fonts={{
-        typography: { fontFamily: '"Helvetica Neue"' },
-        text: { fontFamily: '"Times New Roman"' },
-        display: { fontFamily: 'Arial, sans-serif', fontWeight: 700 },
-        mono: { fontFamily: 'monospace', fontWeight: 100 }
+      createFonts={() => {
+        const fontFamily = 'Rockwell, sans-serif'
+        return {
+          typography: { fontFamily },
+          heading: { fontFamily },
+          subheading: { fontFamily },
+          text: { fontFamily },
+          display: {
+            fontFamily
+          },
+          monospace: {
+            fontFamily
+          }
+        }
       }}
     >
       <Heading.h2>Heading</Heading.h2>
@@ -63,20 +76,267 @@ We recommend using [typefaces](https://github.com/KyleAMathews/typefaces)
   </Story>
 </Preview>
 
-Custom palette colours can be specified. For example, the primary, secondary or brand colors. Either variants of each shade must be specified, or a [material-ui color preset](https://material-ui.com/customization/color/#color) should be used.
+## Custom Colours
+
+Custom palette colours can be specified. For example, the primary, secondary or brand colors.
+
+The optional `createPalette()` prop should either return a [set of material-ui color intentions](https://material-ui.com/customization/palette/#customization) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+
+The material-ui colors can be specified: palette.primary, palette.secondary, palette.error, palette.warning, palette.info or palette.success
+
+Additionally the committed-theme colors can be specified: palette.brand, palette.neutral
 
 <Preview>
-  <Story name="colors">
-    <ThemeProvider paletteColors={{ primary: blueGrey, brand: cyan }}>
-      <Button color="primary">Custom Colours</Button>
+  <Story name="custom-colors">
+    <ThemeProvider
+      createPaletteOptions={() => ({
+        primary: {
+          //blue
+          light: '#4f83cc',
+          main: '#01579b',
+          dark: '#002f6c',
+          contrastText: '#fff'
+        },
+        brand: {
+          //blue
+          light: '#4f83cc',
+          main: '#01579b',
+          dark: '#002f6c',
+          contrastText: '#fff'
+        },
+        secondary: {
+          //yellow
+          light: '#ffff6b',
+          main: '#fdd835',
+          dark: '#c6a700',
+          contrastText: '#000'
+        }
+      })}
+    >
+      <Button color="primary" mr={3}>
+        Custom Primary Button
+      </Button>
+      <Button color="secondary">Custom Secondary Button</Button>
     </ThemeProvider>
   </Story>
 </Preview>
 
-An Example of custom theming, with blue and yellow colours:
+## Custom Shape
+
+The optional `createShape()` prop should either return material-ui shape options i.e. `{ borderRadius: xx }` to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
 
 <Preview>
-  <Story name="custom-theming">
+  <Story name="custom-shape">
+    <ThemeProvider
+      createShape={() => ({
+        borderRadius: 20
+      })}
+    >
+      <Button color="primary" mr={3}>
+        Custom Primary Button
+      </Button>
+      <Button color="secondary">Custom Secondary Button</Button>
+    </ThemeProvider>
+  </Story>
+</Preview>
+
+## Custom Spacing
+
+Override the meaning of spacing props. These are dimensionless values given to things like margin and padding. All Material components will be affected, so Use with care.
+
+The optional `createSpacing()` prop should either return [material-ui spacing options](https://material-ui.com/customization/spacing/) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+
+<Preview>
+  <Story name="custom-spacing">
+    <C.ThemeProvider
+      style={{ width: '100%', height: '100%', border: '1px' }}
+      createSpacing={() => factor => factor * 10}
+    >
+      <Background width="1VH">
+        <C.Column flexWrap="wrap">
+          <C.Flex
+            flexGrow={1}
+            p={3}
+            m={1}
+            justifyContent="space-evenly"
+            border="1px solid black"
+          >
+            <C.Column>
+              <C.Button m={3}>Default</C.Button>
+              <C.Button m={3} color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+            <C.Column>
+              <C.Button m={3} variant="outlined">
+                Default
+              </C.Button>
+              <C.Button m={3} variant="outlined" color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} variant="outlined" color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+            <C.Column>
+              <C.Button m={3} variant="text">
+                Default
+              </C.Button>
+              <C.Button m={3} variant="text" color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} variant="text" color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+            <C.Column>
+              <C.Button disabled={true} m={3}>
+                Default
+              </C.Button>
+              <C.Button disabled={true} m={3} color="primary">
+                Primary
+              </C.Button>
+              <C.Button disabled={true} m={3} color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+          </C.Flex>
+        </C.Column>
+      </Background>
+    </C.ThemeProvider>
+  </Story>
+</Preview>
+
+## Custom Typography
+
+The optional `createTypography()` prop should either return [material-ui typography options](https://material-ui.com/customization/typography/) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults.
+
+<Preview>
+  <Story name="custom-typography">
+    <C.ThemeProvider
+      style={{ width: '100%', height: '100%', border: '1px' }}
+      createTypography={() => ({
+        htmlFontSize: 16,
+        fontSize: 20,
+        h1: {
+          fontSize: '1.2rem'
+        }
+      })}
+    >
+      <Background width="1VH">
+        <C.Flex
+          flexGrow={1}
+          p={3}
+          pt={4}
+          m={1}
+          border="1px solid black"
+          bgcolor="background.default"
+        >
+          <C.Box width={1 / 2}>
+            <C.Typography>System Typography</C.Typography>
+            <C.Heading.h2 gutterBottom>h2. Heading</C.Heading.h2>
+            <C.Heading.h3 gutterBottom>h3. Heading</C.Heading.h3>
+            <C.Heading.h4 gutterBottom>h4. Heading</C.Heading.h4>
+            <C.Subheading.h3 gutterBottom>
+              subheading. Lorem ipsum dolor sit amet, consectetur adipisicing
+              elit. Quos blanditiis tenetur
+            </C.Subheading.h3>
+            <C.Typography variant="body1" gutterBottom>
+              body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+              consectetur.
+            </C.Typography>
+            <C.Typography variant="body2" gutterBottom>
+              body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+              consectetur.
+            </C.Typography>
+          </C.Box>
+          <C.Box width={1 / 2}>
+            <C.Text>Disply Typography</C.Text>
+            <C.Display.d1 gutterBottom>d1. Heading</C.Display.d1>
+            <C.Display.d2 gutterBottom>d2. Heading</C.Display.d2>
+            <C.Text gutterBottom>
+              Text. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore
+              consectetur.
+            </C.Text>
+            <C.Monospace wrap>
+              Monospace. Lorem ipsum dolor sit amet, consectetur adipisicing
+              elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum
+              inventore consectetur.
+            </C.Monospace>
+          </C.Box>
+        </C.Flex>
+      </Background>
+    </C.ThemeProvider>
+  </Story>
+</Preview>
+
+## Custom Global CSS Overrides
+
+The optional `createOverrides()` prop should either return [material-ui overrides options](https://material-ui.com/customization/globals/) to replace the Committed theme defaults, or it should return undefined to use the Material-UI defaults. It is passed the palette created using the `createPaletteOptions()` prop
+
+<Preview>
+  <Story name="custom-overrides">
+    <C.ThemeProvider
+      style={{ width: '100%', height: '100%', border: '1px' }}
+      createOverrides={palette => ({
+        MuiButton: {
+          contained: {
+            color: 'white',
+            backgroundColor: 'red'
+          },
+          containedPrimary: {
+            color: 'black',
+            backgroundColor: 'white'
+          },
+          containedSecondary: {
+            color: 'white',
+            backgroundColor: 'blue'
+          }
+        }
+      })}
+    >
+      <Background width="1VH">
+        <C.Caption>
+          <C.Link href="/components/?path=/docs/components-button--default-story">
+            Buttons
+          </C.Link>
+        </C.Caption>
+        <C.Column flexWrap="wrap">
+          <C.Flex
+            flexGrow={1}
+            p={3}
+            m={1}
+            justifyContent="space-evenly"
+            border="1px solid black"
+          >
+            <C.Column>
+              <C.Button m={3}>Default</C.Button>
+              <C.Button m={3} color="primary">
+                Primary
+              </C.Button>
+              <C.Button m={3} color="secondary">
+                Secondary
+              </C.Button>
+            </C.Column>
+          </C.Flex>
+        </C.Column>
+      </Background>
+    </C.ThemeProvider>
+  </Story>
+</Preview>
+
+## Example theme
+
+An example of a theme with all options customised:
+
+<Preview>
+  <Story name="custom-theme">
     <C.ThemeProvider
       style={{ width: '100%', height: '100%', border: '1px' }}
       createPaletteOptions={() => ({


### PR DESCRIPTION
Introduces new optional props on ThemeProvider:

```
  createPalette?: (paletteColors: PaletteColors) => PaletteOptions
  createFonts?: () => typeof defaultFonts | undefined
  createShape?: () => ShapeOptions | undefined
  createSpacing?: () => SpacingOptions | undefined
  createTypography?: () =>
    | TypographyOptions
    | ((palette: Palette) => TypographyOptions)
    | undefined
  createOverrides?: (paletteColors: PaletteColors) => Overrides | undefined
```

If a prop is not specified, the default committed behaviour will occur. If the function returns undefined, the default material-ui behaviour will occur.

Removed the fonts prop. It is replaced by createFonts()

The default values of these function props are exported in case people want to merge or modify themes downstream. e.g. calling createTypography() but overriding the header font size.