### PR TITLE
Login component

### DIFF
--- a/stories/components/login/Login.tsx
+++ b/stories/components/login/Login.tsx
@@ -1,0 +1,125 @@
+import {
+  Box,
+  Button,
+  Container,
+  Form,
+  Flex,
+  IconButton,
+  InputAdornment,
+  Text,
+  Typography,
+  Alert,
+} from '../../../src'
+import { Icons } from '../../util/Icons'
+import { TextField } from '@material-ui/core'
+import React, { useState } from 'react'
+
+export interface LoginProps {
+  onChangeEmail: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChangePassword: (e: React.ChangeEvent<HTMLInputElement>) => void
+  email: string
+  password: string
+  errorMessage?: string
+  onSignIn: () => void
+  passwordRules?: string
+  submitting?: boolean
+}
+
+export const Login: React.FC<LoginProps> = ({
+  errorMessage,
+  onChangeEmail,
+  onChangePassword,
+  email,
+  password,
+  onSignIn,
+  passwordRules,
+  submitting,
+  children,
+}) => {
+  const [hidePassword, setHidePassword] = useState(true)
+  return (
+    <Container component="main" maxWidth="sm">
+      <Flex alignItems="center" flexDirection="column" mt={3}>
+        {children}
+        {errorMessage && (
+          <Box mb={3}>
+            <Alert severity="error">
+              <Text>{errorMessage}</Text>
+            </Alert>
+          </Box>
+        )}
+        <Form
+          width={1}
+          onSubmit={(e) => {
+            e.preventDefault()
+            onSignIn()
+          }}
+        >
+          <Box mb={3}>
+            <TextField
+              fullWidth
+              required
+              id="email"
+              label="Email Address"
+              name="email"
+              autoComplete="email"
+              autoFocus
+              type="email"
+              value={email}
+              onChange={onChangeEmail}
+              variant="outlined"
+            />
+          </Box>
+
+          <Box mb={1}>
+            <TextField
+              fullWidth
+              required
+              name="password"
+              label="Password"
+              type={hidePassword ? 'password' : 'text'}
+              id="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={onChangePassword}
+              aria-describedby="password-contraints"
+              variant="outlined"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label="toggle password visibility"
+                      onClick={() => setHidePassword((v) => !v)}
+                      edge="end"
+                    >
+                      {hidePassword ? (
+                        <Icons.Visibility />
+                      ) : (
+                        <Icons.VisibilityOff />
+                      )}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </Box>
+
+          {passwordRules && (
+            <Box id="password-contraints">
+              <Typography variant="caption"> {passwordRules}</Typography>
+            </Box>
+          )}
+          <Button
+            mt={3}
+            color="primary"
+            fullWidth
+            type="submit"
+            disabled={submitting}
+          >
+            Sign In
+          </Button>
+        </Form>
+      </Flex>
+    </Container>
+  )
+}

--- a/stories/components/login/login.stories.mdx
+++ b/stories/components/login/login.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
+import { Login } from './Login'
+
+<Meta title="Components/Login" component={Login} />
+
+# Login
+
+A login form following [best practices](web.dev/sign-in-form-best-practices/#checklist).
+
+It uses built in brower validation of emails and passwords with `type="email"` and `type="password"`.
+
+The signin button is disabled while sign in is taking place to prevent accidental multiple login attempts.
+
+The form is mobile friendly. `type=email` is used to bring up the correct keyboard.
+
+The typed in password can viewed with the show password button to make sign in easier.
+
+Accessiblity is considered. `aria-label` and `aria-describedby` is used for password inputs.
+
+<Canvas>
+  <Story name="default">
+    <Login
+      onChangeEmail={() => {}}
+      onChangePassword={() => {}}
+      email="jsmith"
+      password="password"
+      onSignIn={() => {}}
+    />
+  </Story>
+</Canvas>
+
+The `passwordRules` optionally displays the password rules for easier sign in.
+
+<Canvas>
+  <Story name="password rules">
+    <Login
+      onChangeEmail={() => {}}
+      onChangePassword={() => {}}
+      email="jsmith"
+      password="password"
+      onSignIn={() => {}}
+      passwordRules="8 or more characters with one letter and symbol"
+    />
+  </Story>
+</Canvas>
+
+The `errorMessage` can be used to display errors related to sign in.
+
+<Canvas>
+  <Story name="error">
+    <Login
+      onChangeEmail={() => {}}
+      onChangePassword={() => {}}
+      email="jsmith"
+      password="password"
+      onSignIn={() => {}}
+      errorMessage="Account is disabled or does not exist"
+    />
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Login} />

--- a/stories/components/login/login.stories.mdx
+++ b/stories/components/login/login.stories.mdx
@@ -1,31 +1,34 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
+import { Box } from '../../../src'
 import { Login } from './Login'
 
-<Meta title="Components/Login" component={Login} />
+<Meta title="Candidates/Login" component={Login} />
 
 # Login
 
 A login form following [best practices](web.dev/sign-in-form-best-practices/#checklist).
 
-It uses built in brower validation of emails and passwords with `type="email"` and `type="password"`.
+It uses built in browser validation of emails and passwords with `type="email"` and `type="password"`.
 
-The signin button is disabled while sign in is taking place to prevent accidental multiple login attempts.
+The sign in button is disabled while sign in is taking place to prevent accidental multiple login attempts.
 
 The form is mobile friendly. `type=email` is used to bring up the correct keyboard.
 
 The typed in password can viewed with the show password button to make sign in easier.
 
-Accessiblity is considered. `aria-label` and `aria-describedby` is used for password inputs.
+Accessibility is considered. `aria-label` and `aria-describedby` is used for password inputs.
 
 <Canvas>
   <Story name="default">
-    <Login
-      onChangeEmail={() => {}}
-      onChangePassword={() => {}}
-      email="jsmith"
-      password="password"
-      onSignIn={() => {}}
-    />
+    <Box p={3} bgcolor="background.paper">
+      <Login
+        onChangeEmail={() => {}}
+        onChangePassword={() => {}}
+        email="jsmith"
+        password="password"
+        onSignIn={() => {}}
+      />
+    </Box>
   </Story>
 </Canvas>
 
@@ -33,14 +36,16 @@ The `passwordRules` optionally displays the password rules for easier sign in.
 
 <Canvas>
   <Story name="password rules">
-    <Login
-      onChangeEmail={() => {}}
-      onChangePassword={() => {}}
-      email="jsmith"
-      password="password"
-      onSignIn={() => {}}
-      passwordRules="8 or more characters with one letter and symbol"
-    />
+    <Box p={3} bgcolor="background.paper">
+      <Login
+        onChangeEmail={() => {}}
+        onChangePassword={() => {}}
+        email="jsmith@committed.io"
+        password="password"
+        onSignIn={() => {}}
+        passwordRules="8 or more characters with one letter and symbol"
+      />
+    </Box>
   </Story>
 </Canvas>
 
@@ -48,14 +53,16 @@ The `errorMessage` can be used to display errors related to sign in.
 
 <Canvas>
   <Story name="error">
-    <Login
-      onChangeEmail={() => {}}
-      onChangePassword={() => {}}
-      email="jsmith"
-      password="password"
-      onSignIn={() => {}}
-      errorMessage="Account is disabled or does not exist"
-    />
+    <Box p={3} bgcolor="background.paper">
+      <Login
+        onChangeEmail={() => {}}
+        onChangePassword={() => {}}
+        email="jsmith@committed.io"
+        password="password"
+        onSignIn={() => {}}
+        errorMessage="Account is disabled or does not exist"
+      />
+    </Box>
   </Story>
 </Canvas>
 


### PR DESCRIPTION
From BC, follows best practice https://web.dev/sign-in-form-best-practices/#checklist

- Validate email and password using browser error prompts
- Don't disable form submission button when form is partially filled
- Disable sign in button while sign in is taking place
- Ensure sign in form is completely visible on mobile
- Set type=email to bring up correct keyboard on mobile
- Display password rules on signin page
- Provide show password functionality
- Use aria-label and aria-describedby for password inputs

#50

![image](https://user-images.githubusercontent.com/433293/98253667-3e308780-1f73-11eb-8689-2829c2d6e394.png)
