### PR TITLE
AppBar menu

### DIFF
--- a/src/components/AppBar/AppBar.stories.tsx
+++ b/src/components/AppBar/AppBar.stories.tsx
@@ -1,12 +1,28 @@
 import { Meta } from '@storybook/react'
 import React from 'react'
 import { Link as RouterLink, MemoryRouter } from 'react-router-dom'
-import { AppBar, AppBarActions, AppBarButton, AppBarHeading } from '.'
+import {
+  AppBar,
+  AppBarActions,
+  AppBarButton,
+  AppBarHeading,
+  AppBarMenu,
+  AppBarMenuItem,
+} from '.'
+import { Heading } from '../Heading'
+import { Link } from '../Link'
+import { Text } from '../Text'
 
 export default {
   title: 'Components/AppBar',
   component: AppBar,
-  subcomponents: { AppBarHeading, AppBarActions, AppBarButton },
+  subcomponents: {
+    AppBarHeading,
+    AppBarActions,
+    AppBarButton,
+    AppBarMenu,
+    AppBarMenuItem,
+  },
 } as Meta
 
 export const Default: React.FC = () => {
@@ -16,6 +32,36 @@ export const Default: React.FC = () => {
       <AppBarActions>
         <AppBarButton>Login</AppBarButton>
       </AppBarActions>
+    </AppBar>
+  )
+}
+
+/**
+ * AppBarMenuItem components extend Link and have all of the same props.
+ */
+export const WithMenu: React.FC = () => {
+  return (
+    <AppBar>
+      <AppBarHeading>Example</AppBarHeading>
+      <AppBarMenu>
+        <AppBarMenuItem href="/feed">Feed</AppBarMenuItem>
+        <AppBarMenuItem href="/browse">Browse</AppBarMenuItem>
+      </AppBarMenu>
+      <AppBarActions>
+        <AppBarButton>Login</AppBarButton>
+      </AppBarActions>
+    </AppBar>
+  )
+}
+
+export const WithMenuWithoutActions: React.FC = () => {
+  return (
+    <AppBar>
+      <AppBarHeading>Example</AppBarHeading>
+      <AppBarMenu>
+        <AppBarMenuItem href="/feed">Feed</AppBarMenuItem>
+        <AppBarMenuItem href="/browse">Browse</AppBarMenuItem>
+      </AppBarMenu>
     </AppBar>
   )
 }

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -1,8 +1,10 @@
 import type * as Polymorphic from '@radix-ui/react-polymorphic'
 import React, { ComponentProps, forwardRef, PropsWithChildren } from 'react'
 import { CSS, styled } from 'stitches.config'
+import { Box } from '../Box'
 import { Button } from '../Button'
 import { Heading } from '../Heading'
+import { Link } from '../Link'
 
 /**
  * The App Bar should the used for information and actions on the current screen.
@@ -15,10 +17,7 @@ export const AppBar = styled('header', {
   paddingLeft: '$4',
   paddingRight: '$4',
   alignItems: 'center',
-})
-
-const AppBarHeadingContainer = styled('div', {
-  flex: '1',
+  position: 'relative',
 })
 
 const HEADING_TAG = 'h1'
@@ -33,18 +32,21 @@ type AppBarHeadingComponent = Polymorphic.ForwardRefComponent<
 
 export const AppBarHeading = forwardRef(
   ({ children, css, ...props }, forwardedRef) => (
-    <AppBarHeadingContainer>
-      <Heading
-        variant={HEADING_TAG}
-        css={{ color: '$brandContrast', ...css } as CSS}
-        size={1}
-        weight="regular"
-        {...props}
-        ref={forwardedRef}
-      >
-        {children}
-      </Heading>
-    </AppBarHeadingContainer>
+    <>
+      <div>
+        <Heading
+          variant={HEADING_TAG}
+          css={{ color: '$brandContrast', ...css } as CSS}
+          size={1}
+          weight="regular"
+          {...props}
+          ref={forwardedRef}
+        >
+          {children}
+        </Heading>
+      </div>
+      <Box css={{ flex: 1 }} />
+    </>
   )
 ) as AppBarHeadingComponent
 
@@ -71,3 +73,42 @@ export const AppBarButton = forwardRef<
     {children}
   </Button>
 )) as AppBarButtonComponent
+
+export const AppBarMenu: React.FC = ({ children }) => (
+  <Box
+    css={{
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'center',
+      alignContent: 'center',
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+    }}
+  >
+    <Box>
+      <Box
+        css={{
+          height: '100%',
+          display: 'flex',
+          gap: '$5',
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  </Box>
+)
+
+export const AppBarMenuItem = styled(Link, {
+  color: '$brandContrast',
+  textDecoration: 'none',
+  '&:hover': {
+    textDecoration: 'underline',
+  },
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+})

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -88,21 +88,21 @@ export const AppBarMenu: React.FC = ({ children }) => (
       bottom: 0,
     }}
   >
-    <Box>
-      <Box
-        css={{
-          height: '100%',
-          display: 'flex',
-          gap: '$5',
-        }}
-      >
-        {children}
-      </Box>
+    <Box
+      css={{
+        height: '100%',
+        display: 'flex',
+        gap: '$5',
+      }}
+    >
+      {children}
     </Box>
   </Box>
 )
 
-export const AppBarMenuItem = styled(Link, {
+export const AppBarMenuItem: React.FC<
+  React.ComponentProps<typeof Link>
+> = styled(Link, {
   color: '$brandContrast',
   textDecoration: 'none',
   '&:hover': {
@@ -111,4 +111,4 @@ export const AppBarMenuItem = styled(Link, {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-})
+}) as React.FC<React.ComponentProps<typeof Link>>


### PR DESCRIPTION
Stays centred independently of the rest of the AppBar.

AppBarMenuItem extends Link (underline appears on hover).

![image](https://user-images.githubusercontent.com/433293/120796770-2209be80-c533-11eb-8cc7-4632ee72ec30.png)
