### PR TITLE
Make ThemeProvider use body by default

### DIFF
--- a/.storybook/committed/withTheme.tsx
+++ b/.storybook/committed/withTheme.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useDarkMode } from 'storybook-dark-mode'
-import { ThemeProvider } from '../../src'
+import { ThemeProvider, darkTheme, lightTheme } from '../../src'
 import '@fontsource/inter/300.css'
 import '@fontsource/inter/400.css'
 import '@fontsource/inter/700.css'
@@ -14,12 +14,11 @@ import '@fontsource/dosis/300.css'
  * @param {*} Story storybook component to wrap
  */
 export const withTheme = (Story) => {
+  // Clean the theme first
+  document.body.classList.remove(darkTheme)
+  document.body.classList.remove(lightTheme)
+
   const choice = useDarkMode() ? 'dark' : 'light'
-  if (choice === 'dark') {
-    document.body.classList.add('dark-theme')
-  } else {
-    document.body.classList.remove('dark-theme')
-  }
   return (
     <ThemeProvider choice={choice}>
       <Story />

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -12,7 +12,18 @@ const Header = () => (
     </C.AppBarHeading>
     <C.AppBarActions>
       <C.ThemeSwitch />
-      <C.AppBarButton>Logout</C.AppBarButton>
+
+      <C.ConfirmDialog>
+        <C.ConfirmDialogTrigger>
+          <C.AppBarButton>Logout</C.AppBarButton>
+        </C.ConfirmDialogTrigger>
+        <C.ConfirmDialogContent
+          description="Are you sure you want to logout?"
+          title="Confirm Dialog"
+        >
+          <C.ConfirmDialogActions confirm="Yes" />
+        </C.ConfirmDialogContent>
+      </C.ConfirmDialog>
     </C.AppBarActions>
   </C.AppBar>
 )

--- a/src/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -36,7 +36,7 @@ const Example = styled(Paper, {
 })
 
 const Template: Story<ThemeProviderProps> = (args) => (
-  <ThemeProvider {...args}>
+  <ThemeProvider local={true} {...args}>
     <Example>Example</Example>
   </ThemeProvider>
 )
@@ -105,7 +105,7 @@ export const UtilityUseThemeController = () => {
     return <Switch checked={choice == 'dark'} onCheckedChange={toggleChoice} />
   }
   return (
-    <ThemeProvider>
+    <ThemeProvider local={true}>
       <Card css={{ padding: '$6', margin: '$2' }}>
         <CustomSwitch />
       </Card>


### PR DESCRIPTION
The theme provider will now, by default, set the theme using the document body.
This means it will also cover the react portal.

Also adds local prop to return to previous behaviour.
This may be useful, say in components storybook to demonstrate other themes, or anywhere that may require nested themes.

fixes #180