### PR TITLE
ci: removes duplicate builds from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Full CI
+    name: Release
     runs-on: ubuntu-latest
 
     steps:
@@ -34,18 +34,6 @@ jobs:
         if: ${{ env.ACT }}
         run: npm install
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Test
-        run: npm test -- --ci --coverage --maxWorkers=2
-
-      - name: Build
-        run: npm run build
-
-      - name: Build Storybook
-        run: npm run build-storybook -- --quiet
-
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:
@@ -60,6 +48,7 @@ jobs:
         run: npx semantic-release
 
       - name: Publish Docs
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: npm run deploy-storybook -- --ci
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The build, lint and tests were bing run twice in the release script as semantic release also runs
them. So removed a set. Also stops the docs from being published on beta.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Bug fix
[ ] Enhancement
[ ] Documentation
[ ] Deployment
[ ] Process (e.g. improve continuous integration)
[ ] Other, please explain:

**Which issue (if any) does this pull request address?**

Fixes

**What changes did you make?**

**Is there anything you'd like reviewers to focus on?**
